### PR TITLE
Decrypt configuration stored configuraiton on execute

### DIFF
--- a/Docker/Executor.php
+++ b/Docker/Executor.php
@@ -213,10 +213,7 @@ class Executor
         } catch (ClientException $e) {
             throw new UserException("Cannot import data from Storage API: " . $e->getMessage(), $e);
         }
-
-
     }
-
 
 
     /**

--- a/Job/Executor.php
+++ b/Job/Executor.php
@@ -111,7 +111,7 @@ class Executor extends BaseExecutor
                     $components = new Components($this->storageApi);
                     $configuration = $components->getConfiguration($component["id"], $params["config"]);
                     $configId = $params["config"];
-                    $configData = $configuration["configuration"];
+                    $configData = $this->encryptor->decrypt($configuration["configuration"]);
                     $state = $configuration["state"];
                 } catch (ClientException $e) {
                     throw new UserException("Error reading configuration '{$params["config"]}': " . $e->getMessage(), $e);

--- a/Job/Executor.php
+++ b/Job/Executor.php
@@ -35,14 +35,22 @@ class Executor extends BaseExecutor
     protected $encryptor;
 
     /**
+     * @var Components
+     */
+    protected $components;
+
+    /**
      * @param Logger $log
      * @param Temp $temp
+     * @param ObjectEncryptor $encryptor
+     * @param Components $components
      */
-    public function __construct(Logger $log, Temp $temp, ObjectEncryptor $encryptor)
+    public function __construct(Logger $log, Temp $temp, ObjectEncryptor $encryptor, Components $components)
     {
         $this->log = $log;
         $this->temp = $temp;
         $this->encryptor = $encryptor;
+        $this->components = $components;
     }
 
     /**
@@ -108,8 +116,7 @@ class Executor extends BaseExecutor
             } else {
                 // Read config from storage
                 try {
-                    $components = new Components($this->storageApi);
-                    $configuration = $components->getConfiguration($component["id"], $params["config"]);
+                    $configuration = $this->components->getConfiguration($component["id"], $params["config"]);
                     $configId = $params["config"];
                     $configData = $this->encryptor->decrypt($configuration["configuration"]);
                     $state = $configuration["state"];

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,7 @@
 services:
+    syrup.components:
+        class: Keboola\StorageApi\Components
+        arguments: [@syrup.storage_api]
     syrup.job_executor:
         class: Keboola\DockerBundle\Job\Executor
-        arguments: [@logger, @syrup.temp, @syrup.object_encryptor]
+        arguments: [@logger, @syrup.temp, @syrup.object_encryptor, @syrup.components]

--- a/Tests/Docker/ExecutorTest.php
+++ b/Tests/Docker/ExecutorTest.php
@@ -146,7 +146,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
         $process = $executor->run($container, "testsuite");
@@ -200,7 +200,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         try {
             $executor->initialize($container, $config);
@@ -249,7 +249,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
         $executor->run($container, "testsuite");
@@ -301,7 +301,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
         $executor->run($container, "testsuite");
@@ -353,7 +353,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
         $executor->run($container, "testsuite");
@@ -417,7 +417,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
         $executor->storeDataArchive($container, ['sandbox', 'docker-test']);
@@ -476,7 +476,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         try {
             $executor->initialize($container, $config);
@@ -528,7 +528,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         try {
             $executor->initialize($container, $config);
@@ -593,7 +593,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
     }
@@ -637,7 +637,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config);
         $this->assertFileExists($this->tmpDir . "/data/in/state.json");
@@ -686,7 +686,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log, $encryptor);
+        $executor = new Executor($this->client, $log);
         $executor->setTmpFolder($this->tmpDir);
         $executor->initialize($container, $config, array("lastUpdate" => "today"));
         $this->assertFileExists($this->tmpDir . "/data/in/state.json");

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -570,7 +570,8 @@ class FunctionalTests extends \PHPUnit_Framework_TestCase
                     "#key2" => $configEncryptor->encrypt("value2"),
                 ]
             ],
-            "state" => []];
+            "state" => []
+        ];
         $componentsStub = $this->getMockBuilder("\\Keboola\\StorageApi\\Components")
             ->disableOriginalConstructor()
             ->getMock();
@@ -578,7 +579,7 @@ class FunctionalTests extends \PHPUnit_Framework_TestCase
             ->method("getConfiguration")
             ->with("docker-config-dump", 1)
             ->will($this->returnValue($configData))
-            ;
+        ;
 
         $jobExecutor = new Executor($log, $this->temp, $configEncryptor, $componentsStub);
 
@@ -592,38 +593,34 @@ class FunctionalTests extends \PHPUnit_Framework_TestCase
                             'type' => 'other',
                             'name' => 'Docker Config Dump',
                             'description' => 'Testing Docker',
-                            'longDescription' => NULL,
+                            'longDescription' => null,
                             'hasUI' => false,
                             'hasRun' => true,
                             'ico32' => 'https://d3iz2gfan5zufq.cloudfront.net/images/cloud-services/docker-demo-32-1.png',
                             'ico64' => 'https://d3iz2gfan5zufq.cloudfront.net/images/cloud-services/docker-demo-64-1.png',
-                            'data' =>
-                                array (
-                                    'definition' =>
-                                        array (
-                                            'type' => 'dockerhub',
-                                            'uri' => 'keboola/config-dump',
-                                        ),
-                                ),
-                            'flags' =>
-                                array (
-                                ),
+                            'data' => array (
+                                'definition' =>
+                                    array (
+                                        'type' => 'dockerhub',
+                                        'uri' => 'keboola/config-dump',
+                                    ),
+                            ),
+                            'flags' => array (),
                             'uri' => 'https://syrup.keboola.com/docker/docker-config-dump',
                         )
                 )
-            );
+        );
         $sapiStub = $this->getMockBuilder("\\Keboola\\StorageApi\\Client")
             ->disableOriginalConstructor()
             ->getMock();
         $sapiStub->expects($this->once())
             ->method("indexAction")
             ->will($this->returnValue($indexActionValue))
-            ;
+        ;
         $jobExecutor->setStorageApi($sapiStub);
 
         $response = $jobExecutor->execute($job);
         $config = Yaml::parse($response["message"]);
         $this->assertEquals("value2", $config["parameters"]["#key2"]);
     }
-
 }


### PR DESCRIPTION
Pokud spustím např. ex-adform napřímo pomocí `configData` se zašifrovanými credentials:

![image](https://cloud.githubusercontent.com/assets/903531/10340737/d9f97fce-6d11-11e5-8f08-45d5285f3b8e.png)

tak to šlape v pohodě. Pokud to samé uložím do konfigurace a spustím ji pomocí `config` parametru zřejmě se to nerozšifruje.