### PR TITLE
Image parameters

### DIFF
--- a/Docker/Configuration/Container.php
+++ b/Docker/Configuration/Container.php
@@ -13,7 +13,8 @@ class Container extends Configuration
         // System
         $root
             ->children()
-                ->variableNode("parameters")
+                ->variableNode("parameters")->end()
+                ->variableNode("image_parameters")
         ;
         $storage = $root
             ->children()

--- a/Docker/Configuration/Image.php
+++ b/Docker/Configuration/Image.php
@@ -78,6 +78,7 @@ class Image extends Configuration
                         ->end()
                     ->end()
                 ->end()
+            ->variableNode("image_parameters")->end()
             ->integerNode("cpu_shares")->min(0)->defaultValue(1024)->end()
             ->scalarNode("memory")->defaultValue("64m")->end()
             ->scalarNode("configuration_format")

--- a/Docker/Executor.php
+++ b/Docker/Executor.php
@@ -160,11 +160,13 @@ class Executor
     /**
      * @param Client $storageApi
      * @param Logger $log
+     * @param string $tmpFolder
      */
-    public function __construct(Client $storageApi, Logger $log)
+    public function __construct(Client $storageApi, Logger $log, $tmpFolder)
     {
         $this->setStorageApiClient($storageApi);
         $this->setLog($log);
+        $this->setTmpFolder($tmpFolder);
     }
 
 
@@ -187,7 +189,9 @@ class Executor
         $adapter = new Configuration\Container\Adapter($container->getImage()->getConfigFormat());
         try {
             $configData = $this->configData;
+            // remove runtime parameters which is not supposed to be passed into the container
             unset($configData['runtime']);
+            // add image parameters which are supposed to be passed into the container
             $configData['image_parameters'] = $container->getImage()->getImageParameters();
             $adapter->setConfig($configData);
         } catch (InvalidConfigurationException $e) {
@@ -233,11 +237,11 @@ class Executor
 
     /**
      * @param Container $container
-     * @param $id
-     * @return \Symfony\Component\Process\Process
-     * @throws \Exception
+     * @param string $id
+     * @param array $tokenInfo Storage API token information as returned by verifyToken()
+     * @return Process
      */
-    public function run(Container $container, $id)
+    public function run(Container $container, $id, $tokenInfo)
     {
         // Check if container not running
         $process = new Process('sudo docker ps | grep ' . escapeshellarg($id) . ' | wc -l');
@@ -254,13 +258,12 @@ class Executor
         }
 
         // set environment variables
-        $tokenInfo = $this->getStorageApiClient()->getLogData();
         $envs = [
             "KBC_RUNID" => $this->getStorageApiClient()->getRunId(),
             "KBC_PROJECTID" => $tokenInfo["owner"]["id"]
         ];
         if ($container->getImage()->getForwardToken()) {
-            $envs["KBC_TOKEN"] = $this->getStorageApiClient()->getTokenString();
+            $envs["KBC_TOKEN"] = $tokenInfo["token"];
         }
         if ($container->getImage()->getForwardTokenDetails()) {
             $envs["KBC_PROJECTNAME"] = $tokenInfo["owner"]["name"];

--- a/Docker/Executor.php
+++ b/Docker/Executor.php
@@ -188,6 +188,7 @@ class Executor
         try {
             $configData = $this->configData;
             unset($configData['runtime']);
+            $configData['image_parameters'] = $container->getImage()->getImageParameters();
             $adapter->setConfig($configData);
         } catch (InvalidConfigurationException $e) {
             throw new UserException("Error in configuration: " . $e->getMessage(), $e);

--- a/Docker/Image.php
+++ b/Docker/Image.php
@@ -268,7 +268,7 @@ class Image
      */
     public function setImageParameters($imageParameters)
     {
-        $this->imageParameters = $this->encryptor->decrypt($imageParameters);
+        $this->imageParameters = $imageParameters;
         return $this;
     }
 

--- a/Docker/Image/DockerHub/PrivateRepository.php
+++ b/Docker/Image/DockerHub/PrivateRepository.php
@@ -10,40 +10,10 @@ use Symfony\Component\Process\Process;
 
 class PrivateRepository extends Image\DockerHub
 {
-
     protected $loginEmail;
     protected $loginUsername;
     protected $loginPassword;
     protected $loginServer;
-
-    /**
-     * @var ObjectEncryptor
-     */
-    protected $encryptor;
-
-    public function __construct(ObjectEncryptor $encryptor)
-    {
-        $this->setEncryptor($encryptor);
-    }
-
-    /**
-     * @return ObjectEncryptor
-     */
-    public function getEncryptor()
-    {
-        return $this->encryptor;
-    }
-
-    /**
-     * @param ObjectEncryptor $encryptor
-     * @return $this
-     */
-    public function setEncryptor($encryptor)
-    {
-        $this->encryptor = $encryptor;
-
-        return $this;
-    }
 
     /**
      * @return mixed

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -93,7 +93,8 @@ Configuration file may contain these sections:
 
  - `storage` - list of input and output mappings and Storage API token, if required
  - `system` - copy of system configuration (eg. image tag)
- - `parameters` - variable parameters for the container
+ - `parameters` - variable parameters for the container specified by the end-user (UI or API call)
+ - `image_parameters` - variable parameters for the container specified in the component (image) definition, these are specified by the developer and cannot be changed by the end-user
 
 ### State file
 

--- a/Job/Executor.php
+++ b/Job/Executor.php
@@ -203,7 +203,7 @@ class Executor extends BaseExecutor
                 $image = Image::factory($this->encryptor, $this->log, $dummyConfig);
                 $image->setConfigFormat($params["format"]);
                 $container = new Container($image, $this->log);
-                $executor->initialize($container, $configData, $state);
+                $executor->initialize($container, $configData, $state, true);
                 $executor->storeDataArchive($container, ['sandbox', 'docker']);
                 $message = 'Configuration prepared.';
                 $this->log->info($message);
@@ -213,7 +213,7 @@ class Executor extends BaseExecutor
 
                 $image = Image::factory($this->encryptor, $this->log, $component["data"]);
                 $container = new Container($image, $this->log);
-                $executor->initialize($container, $configData, $state);
+                $executor->initialize($container, $configData, $state, true);
                 $executor->storeDataArchive($container, ['input', 'docker', $component['id']]);
                 $message = 'Image configuration prepared.';
                 $this->log->info($message);
@@ -223,7 +223,7 @@ class Executor extends BaseExecutor
 
                 $image = Image::factory($this->encryptor, $this->log, $component["data"]);
                 $container = new Container($image, $this->log);
-                $executor->initialize($container, $configData, $state);
+                $executor->initialize($container, $configData, $state, true);
                 $process = $executor->run($container, $containerId, $this->tokenInfo);
                 $executor->storeDataArchive($container, ['dry-run', 'docker', $component['id']]);
 
@@ -240,7 +240,7 @@ class Executor extends BaseExecutor
 
                 $image = Image::factory($this->encryptor, $this->log, $component["data"]);
                 $container = new Container($image, $this->log);
-                $executor->initialize($container, $configData, $state);
+                $executor->initialize($container, $configData, $state, false);
                 $process = $executor->run($container, $containerId, $this->tokenInfo);
 
                 $executor->storeOutput($container, $state);

--- a/Job/Executor.php
+++ b/Job/Executor.php
@@ -1,6 +1,7 @@
 <?php
 namespace Keboola\DockerBundle\Job;
 
+use Keboola\DockerBundle\Docker\Executor as DockerExecutor;
 use Keboola\DockerBundle\Encryption\ComponentProjectWrapper;
 use Keboola\DockerBundle\Encryption\ComponentWrapper;
 use Keboola\DockerBundle\Service\ComponentsService;
@@ -53,6 +54,11 @@ class Executor extends BaseExecutor
     protected $encryptionComponentProject;
 
     /**
+     * @var array Cached token information
+     */
+    private $tokenInfo;
+
+    /**
      * @param Logger $log
      * @param Temp $temp
      * @param ObjectEncryptor $encryptor
@@ -101,9 +107,9 @@ class Executor extends BaseExecutor
      */
     public function execute(Job $job)
     {
-        $tokenInfo = $this->storageApi->verifyToken();
+        $this->tokenInfo = $this->storageApi->verifyToken();
 
-        $this->encryptionComponentProject->setProjectId($tokenInfo["owner"]["id"]);
+        $this->encryptionComponentProject->setProjectId($this->tokenInfo["owner"]["id"]);
         if (isset($job->getRawParams()["component"])) {
             $this->encryptionComponent->setComponentId($job->getRawParams()["component"]);
             $this->encryptionComponentProject->setComponentId($job->getRawParams()["component"]);
@@ -136,7 +142,6 @@ class Executor extends BaseExecutor
             if (!$this->storageApi->getRunId()) {
                 $this->storageApi->generateRunId();
             }
-            $containerId = $component["id"] . "-" . $this->storageApi->getRunId();
             $processor = new DockerProcessor($component['id']);
             // attach the processor to all handlers and channels
             $this->log->pushProcessor([$processor, 'processRecord']);
@@ -162,8 +167,21 @@ class Executor extends BaseExecutor
                 }
             }
         }
+        return $this->doExecute($component, $params, $configData, $state);
+    }
 
-        $executor = new \Keboola\DockerBundle\Docker\Executor($this->storageApi, $this->log);
+    /**
+     * @param $component
+     * @param $params
+     * @param $configData
+     * @param $state
+     * @return array
+     * @throws \Exception
+     */
+    private function doExecute($component, $params, $configData, $state)
+    {
+        $executor = new DockerExecutor($this->storageApi, $this->log, $this->temp->getTmpFolder());
+        $containerId = $component["id"] . "-" . $this->storageApi->getRunId();
         if ($component && isset($component["id"])) {
             $executor->setComponentId($component["id"]);
         }
@@ -184,37 +202,29 @@ class Executor extends BaseExecutor
                 );
                 $image = Image::factory($this->encryptor, $this->log, $dummyConfig);
                 $image->setConfigFormat($params["format"]);
-
                 $container = new Container($image, $this->log);
-
-                $executor->setTmpFolder($this->temp->getTmpFolder());
                 $executor->initialize($container, $configData, $state);
                 $executor->storeDataArchive($container, ['sandbox', 'docker']);
-
                 $message = 'Configuration prepared.';
                 $this->log->info($message);
-                return array("message" => $message);
+                break;
             case 'input':
                 $this->log->info("Preparing image configuration.", $configData);
 
                 $image = Image::factory($this->encryptor, $this->log, $component["data"]);
                 $container = new Container($image, $this->log);
-
-                $executor->setTmpFolder($this->temp->getTmpFolder());
                 $executor->initialize($container, $configData, $state);
                 $executor->storeDataArchive($container, ['input', 'docker', $component['id']]);
-
                 $message = 'Image configuration prepared.';
                 $this->log->info($message);
-                return array("message" => $message);
+                break;
             case 'dry-run':
-                $image = Image::factory($this->encryptor, $this->log, $component["data"]);
-                $container = new Container($image, $this->log);
                 $this->log->info("Running Docker container '{$component['id']}'.", $configData);
 
-                $executor->setTmpFolder($this->temp->getTmpFolder());
+                $image = Image::factory($this->encryptor, $this->log, $component["data"]);
+                $container = new Container($image, $this->log);
                 $executor->initialize($container, $configData, $state);
-                $process = $executor->run($container, $containerId);
+                $process = $executor->run($container, $containerId, $this->tokenInfo);
                 $executor->storeDataArchive($container, ['dry-run', 'docker', $component['id']]);
 
                 if ($process->getOutput()) {
@@ -224,15 +234,15 @@ class Executor extends BaseExecutor
                 }
 
                 $this->log->info("Docker container '{$component['id']}' finished.");
-                return array("message" => $message);
+                break;
             case 'run':
-                $image = Image::factory($this->encryptor, $this->log, $component["data"]);
-                $container = new Container($image, $this->log);
                 $this->log->info("Running Docker container '{$component['id']}'.", $configData);
 
-                $executor->setTmpFolder($this->temp->getTmpFolder());
+                $image = Image::factory($this->encryptor, $this->log, $component["data"]);
+                $container = new Container($image, $this->log);
                 $executor->initialize($container, $configData, $state);
-                $process = $executor->run($container, $containerId);
+                $process = $executor->run($container, $containerId, $this->tokenInfo);
+
                 $executor->storeOutput($container, $state);
                 if ($process->getOutput()) {
                     $message = $process->getOutput();
@@ -241,10 +251,11 @@ class Executor extends BaseExecutor
                 }
 
                 $this->log->info("Docker container '{$component['id']}' finished.");
-                return array("message" => $message);
+                break;
             default:
                 throw new ApplicationException("Invalid run mode " . $params['mode']);
         }
+        return array("message" => $message);
     }
 
     /**

--- a/Tests/Docker/ExecutorTest.php
+++ b/Tests/Docker/ExecutorTest.php
@@ -136,7 +136,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $process = $executor->run($container, "testsuite", $this->client->verifyToken());
         $this->assertContains("Processed 1 rows.", trim($process->getOutput()));
         $ret = $container->getRunCommand('test');
@@ -204,7 +204,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $process = $executor->run($container, "testsuite", $this->client->verifyToken());
         $this->assertContains("Processed 1 rows.", trim($process->getOutput()));
         $ret = $container->getRunCommand('test');
@@ -281,7 +281,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $process = $executor->run($container, "testsuite", $this->client->verifyToken());
         $this->assertContains("Processed 1 rows.", trim($process->getOutput()));
         $ret = $container->getRunCommand('test');
@@ -336,7 +336,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
         try {
-            $executor->initialize($container, $config);
+            $executor->initialize($container, $config, [], false);
             $executor->run($container, "testsuite", $this->client->verifyToken());
             $this->fail("Timeouted process should raise exception.");
         } catch (ProcessTimedOutException $e) {
@@ -383,7 +383,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $executor->run($container, "testsuite", $this->client->verifyToken());
         $ret = $container->getRunCommand('test');
         $this->assertContains('KBC_PROJECTID=', $ret);
@@ -434,7 +434,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $executor->run($container, "testsuite", $this->client->verifyToken());
         $ret = $container->getRunCommand('test');
         $this->assertContains('KBC_TOKEN=', $ret);
@@ -486,7 +486,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $tokenInfo = $this->client->verifyToken();
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $executor->run($container, "testsuite", $tokenInfo);
         $ret = $container->getRunCommand('test');
         $this->assertNotContains('KBC_TOKEN=', $ret);
@@ -548,7 +548,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container = new MockContainer($image, $log);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $executor->storeDataArchive($container, ['sandbox', 'docker-test']);
         $this->assertFileExists(
             $this->tmpDir . DIRECTORY_SEPARATOR . 'zip' . DIRECTORY_SEPARATOR . 'data.zip'
@@ -607,7 +607,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
         try {
-            $executor->initialize($container, $config);
+            $executor->initialize($container, $config, [], false);
             $this->fail("Invalid configuration must raise UserException.");
         } catch (UserException $e) {
         }
@@ -658,7 +658,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
         try {
-            $executor->initialize($container, $config);
+            $executor->initialize($container, $config, [], false);
             $this->fail("Invalid configuration must raise UserException.");
         } catch (UserException $e) {
         }
@@ -721,7 +721,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container = new MockContainer($image, $log);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
     }
 
     public function testExecutorStoreEmptyStateFile()
@@ -764,7 +764,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config);
+        $executor->initialize($container, $config, [], false);
         $this->assertFileExists($this->tmpDir . "/data/in/state.json");
         $this->assertEquals(
             new \stdclass(),
@@ -812,7 +812,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container->setRunMethod($callback);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config, array("lastUpdate" => "today"));
+        $executor->initialize($container, $config, ["lastUpdate" => "today"], false);
         $this->assertFileExists($this->tmpDir . "/data/in/state.json");
         $this->assertEquals(
             "{\n    \"lastUpdate\": \"today\"\n}",
@@ -851,7 +851,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container = new MockContainer($image, $log);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, $config, []);
+        $executor->initialize($container, $config, [], false);
         $configFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'config.yml';
         $this->assertFileExists($configFile);
         $config = Yaml::parse($configFile);
@@ -890,7 +890,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $container = new MockContainer($image, $log);
 
         $executor = new Executor($this->client, $log, $this->tmpDir);
-        $executor->initialize($container, [], []);
+        $executor->initialize($container, [], [], false);
         $configFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'config.yml';
         $this->assertFileExists($configFile);
         $config = Yaml::parse($configFile);
@@ -898,4 +898,41 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('pond', $config['image_parameters']['baz']['lily']);
         $this->assertEquals('someString', $config['image_parameters']['#encrypted']);
     }
+
+    public function testExecutorImageParametersNoEncrypt()
+    {
+        $encryptor = new ObjectEncryptor();
+        $encryptor->pushWrapper(new BaseWrapper(md5(uniqid())));
+        $encrypted = $encryptor->encrypt('someString');
+
+        $imageConfig = [
+            "definition" => [
+                "type" => "dockerhub",
+                "uri" => "keboola/docker-config-encrypt-verify"
+            ],
+            "configuration_format" => "yaml",
+            "image_parameters" => [
+                "foo" => "bar",
+                "baz" => [
+                    "lily" => "pond"
+                ],
+                "#encrypted" => $encrypted
+            ]
+        ];
+
+        $log = new Logger("null");
+        $log->pushHandler(new NullHandler());
+        $image = Image::factory($encryptor, $log, $imageConfig);
+        $container = new MockContainer($image, $log);
+
+        $executor = new Executor($this->client, $log, $this->tmpDir);
+        $executor->initialize($container, [], [], true);
+        $configFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'config.yml';
+        $this->assertFileExists($configFile);
+        $config = Yaml::parse($configFile);
+        $this->assertEquals('bar', $config['image_parameters']['foo']);
+        $this->assertEquals('pond', $config['image_parameters']['baz']['lily']);
+        $this->assertEquals($encrypted, $config['image_parameters']['#encrypted']);
+    }
+
 }

--- a/Tests/Docker/ExecutorTest.php
+++ b/Tests/Docker/ExecutorTest.php
@@ -135,10 +135,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
-        $process = $executor->run($container, "testsuite");
+        $process = $executor->run($container, "testsuite", $this->client->verifyToken());
         $this->assertContains("Processed 1 rows.", trim($process->getOutput()));
         $ret = $container->getRunCommand('test');
         // make sure that the token is NOT forwarded by default
@@ -204,10 +203,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
-        $process = $executor->run($container, "testsuite");
+        $process = $executor->run($container, "testsuite", $this->client->verifyToken());
         $this->assertContains("Processed 1 rows.", trim($process->getOutput()));
         $ret = $container->getRunCommand('test');
         // make sure that the token is NOT forwarded by default
@@ -282,10 +280,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
-        $process = $executor->run($container, "testsuite");
+        $process = $executor->run($container, "testsuite", $this->client->verifyToken());
         $this->assertContains("Processed 1 rows.", trim($process->getOutput()));
         $ret = $container->getRunCommand('test');
         // make sure that the token is NOT forwarded by default
@@ -337,11 +334,10 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         try {
             $executor->initialize($container, $config);
-            $executor->run($container, "testsuite");
+            $executor->run($container, "testsuite", $this->client->verifyToken());
             $this->fail("Timeouted process should raise exception.");
         } catch (ProcessTimedOutException $e) {
             $this->assertContains('exceeded the timeout', $e->getMessage());
@@ -386,10 +382,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
-        $executor->run($container, "testsuite");
+        $executor->run($container, "testsuite", $this->client->verifyToken());
         $ret = $container->getRunCommand('test');
         $this->assertContains('KBC_PROJECTID=', $ret);
         $this->assertNotContains('KBC_TOKEN=', $ret);
@@ -438,10 +433,9 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
-        $executor->run($container, "testsuite");
+        $executor->run($container, "testsuite", $this->client->verifyToken());
         $ret = $container->getRunCommand('test');
         $this->assertContains('KBC_TOKEN=', $ret);
         $this->assertContains(STORAGE_API_TOKEN, $ret);
@@ -490,10 +484,10 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $tokenInfo = $this->client->verifyToken();
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
-        $executor->run($container, "testsuite");
+        $executor->run($container, "testsuite", $tokenInfo);
         $ret = $container->getRunCommand('test');
         $this->assertNotContains('KBC_TOKEN=', $ret);
         $this->assertContains('KBC_PROJECTID=', $ret);
@@ -501,7 +495,6 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('KBC_TOKENID=', $ret);
         $this->assertContains('KBC_TOKENDESC=', $ret);
 
-        $tokenInfo = $this->client->getLogData();
         $this->assertContains(strval($tokenInfo["owner"]["id"]), $ret);
         $this->assertContains(str_replace('"', '\"', $tokenInfo["owner"]["name"]), $ret);
         $this->assertContains(strval($tokenInfo["id"]), $ret);
@@ -554,8 +547,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
         $executor->storeDataArchive($container, ['sandbox', 'docker-test']);
         $this->assertFileExists(
@@ -613,8 +605,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         try {
             $executor->initialize($container, $config);
             $this->fail("Invalid configuration must raise UserException.");
@@ -665,8 +656,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         try {
             $executor->initialize($container, $config);
             $this->fail("Invalid configuration must raise UserException.");
@@ -730,8 +720,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
     }
 
@@ -774,8 +763,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config);
         $this->assertFileExists($this->tmpDir . "/data/in/state.json");
         $this->assertEquals(
@@ -823,8 +811,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
 
         $container->setRunMethod($callback);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config, array("lastUpdate" => "today"));
         $this->assertFileExists($this->tmpDir . "/data/in/state.json");
         $this->assertEquals(
@@ -863,8 +850,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $image = Image::factory($encryptor, $log, $imageConfig);
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, $config, []);
         $configFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'config.yml';
         $this->assertFileExists($configFile);
@@ -903,8 +889,7 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $image = Image::factory($encryptor, $log, $imageConfig);
         $container = new MockContainer($image, $log);
 
-        $executor = new Executor($this->client, $log);
-        $executor->setTmpFolder($this->tmpDir);
+        $executor = new Executor($this->client, $log, $this->tmpDir);
         $executor->initialize($container, [], []);
         $configFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'config.yml';
         $this->assertFileExists($configFile);

--- a/Tests/Docker/ExecutorTest.php
+++ b/Tests/Docker/ExecutorTest.php
@@ -934,5 +934,4 @@ class ExecutorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('pond', $config['image_parameters']['baz']['lily']);
         $this->assertEquals($encrypted, $config['image_parameters']['#encrypted']);
     }
-
 }


### PR DESCRIPTION
Omylem jsem tam zamergoval zmenu parametru u executoru, tak je to trosku neprehledny, ale nejdulezitejsi zmena je tohle:
https://github.com/keboola/docker-bundle/compare/image-parameters?expand=1#diff-6b9751d70869d5428e86cc16d56c8655L178
a vola se to tady
https://github.com/keboola/docker-bundle/compare/image-parameters?expand=1#diff-3dcd57d4e048464e12486e837ab2e023L217

Parametry z image se tedy rozsifruji az v okamziku kdy se predavaji containeru (ne driv) a rozsfiruji se pouze v pripade, ze se ten container spusti na ostro.

testy:
https://github.com/keboola/docker-bundle/compare/image-parameters?expand=1#diff-eb3df0823d182793cd90f98635d7027eR924