### PR TITLE
sync action error message

### DIFF
--- a/Controller/ActionController.php
+++ b/Controller/ActionController.php
@@ -125,11 +125,7 @@ class ActionController extends \Keboola\Syrup\Controller\ApiController
 
         $container = new Container($image, $this->container->get('logger'));
         $executor->initialize($container, $configData, $state, false, $request->get("action"));
-        try {
-            $message = $executor->run($container, $containerId, $tokenInfo, $configId);
-        } catch (UserException $e) {
-            throw new UserException($e->getMessage(), $e);
-        }
+        $message = $executor->run($container, $containerId, $tokenInfo, $configId);
         $executor->storeOutput($container, $state);
         $this->container->get('logger')->info("Docker container '{$component['id']}' finished.");
 

--- a/Controller/ActionController.php
+++ b/Controller/ActionController.php
@@ -128,7 +128,7 @@ class ActionController extends \Keboola\Syrup\Controller\ApiController
         try {
             $message = $executor->run($container, $containerId, $tokenInfo, $configId);
         } catch (UserException $e) {
-            throw new UserException("Action '{$request->get("action")}' finished with an error: " . $e->getMessage(), $e);
+            throw new UserException($e->getMessage(), $e);
         }
         $executor->storeOutput($container, $state);
         $this->container->get('logger')->info("Docker container '{$component['id']}' finished.");

--- a/Tests/Controller/ActionControllerTest.php
+++ b/Tests/Controller/ActionControllerTest.php
@@ -78,7 +78,7 @@ class ActionControllerTest extends WebTestCase
 
         return $storageServiceStub;
     }
-    
+
     protected function getStorageServiceStubDcaPython()
     {
         $storageServiceStub = $this->getMockBuilder("\\Keboola\\Syrup\\Service\\StorageApi\\StorageApiService")
@@ -190,7 +190,7 @@ class ActionControllerTest extends WebTestCase
         $ctrl->preExecute($request);
         $ctrl->processAction($request);
     }
-    
+
     /**
      * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
      * @expectedExceptionMessage Action 'somethingelse' not found
@@ -254,8 +254,8 @@ class ActionControllerTest extends WebTestCase
         $ctrl->preExecute($request);
         $ctrl->processAction($request);
     }
-    
-    
+
+
     public function prepareRequest($method, $parameters = null)
     {
         $content = '
@@ -333,7 +333,7 @@ class ActionControllerTest extends WebTestCase
 
     /**
      * @expectedException \Keboola\Syrup\Exception\UserException
-     * @expectedExceptionMessage Action 'usererror' finished with an error: user error
+     * @expectedExceptionMessage user error
      */
     public function testUserException()
     {
@@ -440,7 +440,7 @@ class ActionControllerTest extends WebTestCase
 
     /**
      * @expectedException \Keboola\Syrup\Exception\UserException
-     * @expectedExceptionMessage Action 'decrypt' finished with an error: failed
+     * @expectedExceptionMessage failed
      */
     public function testDecryptMismatch()
     {


### PR DESCRIPTION
Info o to že akce skončila chybou je v message imho duplicitní a pokud tu chybu zobrazujeme v ui tak to reálnou hlášku která uživatele zajímá odsouvá dál:
![image](https://cloud.githubusercontent.com/assets/903531/15284568/574c7fa0-1b52-11e6-98c9-04e2f050aa34.png)
