### PR TITLE
Make clear that out of memory is container

### DIFF
--- a/Docker/Container.php
+++ b/Docker/Container.php
@@ -280,7 +280,7 @@ class Container
                 ]
             ];
             throw new OutOfMemoryException(
-                "Out of memory (exceeded {$this->getImage()->getSourceComponent()->getMemory()})",
+                "Component out of memory (exceeded {$this->getImage()->getSourceComponent()->getMemory()})",
                 null,
                 $data
             );

--- a/Tests/Functional/ContainerErrorHandlingTest.php
+++ b/Tests/Functional/ContainerErrorHandlingTest.php
@@ -265,12 +265,11 @@ class ContainerErrorHandlingTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-     /**
-     * @expectedException \Keboola\DockerBundle\Exception\OutOfMemoryException
-     * @expectedExceptionMessage Out of memory
-     */
     public function testOutOfMemory()
     {
+        $this->expectException(\Keboola\DockerBundle\Exception\OutOfMemoryException::class);
+        $this->expectExceptionMessage('Component out of memory');
+
         $temp = new Temp('docker');
         $imageConfiguration = $this->getImageConfiguration();
         $imageConfiguration["data"]["memory"] = "32m";


### PR DESCRIPTION
Got a ticket that is not clear what is out of memory.

This will add part saying that out of memory is container.
