### PR TITLE
feat: swap

### DIFF
--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -194,4 +194,38 @@ class ComponentTest extends TestCase
             self::assertContains('Invalid repository_type', $e->getMessage());
         }
     }
+
+
+    public function testHasSwap()
+    {
+        $componentData = [
+            'id' => 'keboola.ex-generic',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'dummy',
+                ],
+            ],
+        ];
+        $component = new Component($componentData);
+        self::assertFalse($component->hasNoSwap());
+    }
+
+    public function testHasNoSwap()
+    {
+        $componentData = [
+            'id' => 'keboola.ex-generic',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'dummy',
+                ],
+            ],
+            'features' => [
+                'no-swap'
+            ]
+        ];
+        $component = new Component($componentData);
+        self::assertTrue($component->hasNoSwap());
+    }
 }

--- a/Tests/Docker/Container/ContainerTest.php
+++ b/Tests/Docker/Container/ContainerTest.php
@@ -21,18 +21,6 @@ class ContainerTest extends BaseContainerTest
         $imageConfiguration['features'] = ['container-root-user'];
         $container = $this->getContainer($imageConfiguration, $runCommandOptions, [], false);
 
-        // block devices
-        $process = new Process('lsblk --nodeps --output NAME --noheadings 2>/dev/null');
-        $process->mustRun();
-        $devices = array_filter(explode("\n", $process->getOutput()), function ($device) {
-            return !empty($device);
-        });
-        $deviceLimits = '';
-        foreach ($devices as $device) {
-            $deviceLimits .= " --device-write-bps '/dev/{$device}:50m'";
-            $deviceLimits .= " --device-read-bps '/dev/{$device}:50m'";
-        }
-
         $expected = "sudo timeout --signal=SIGKILL 3600"
             . " docker run"
             . " --volume '" . $this->getTempDir() . "/data:/data'"
@@ -40,7 +28,6 @@ class ContainerTest extends BaseContainerTest
             . " --memory '256m'"
             . " --net 'bridge'"
             . " --cpus '2'"
-            . $deviceLimits
             . " --env \"var=val\""
             . " --env \"příliš=žluťoučký\""
             . " --env \"var2=weird = '\\\"value\""

--- a/Tests/Docker/Container/ContainerTest.php
+++ b/Tests/Docker/Container/ContainerTest.php
@@ -38,7 +38,6 @@ class ContainerTest extends BaseContainerTest
             . " --volume '" . $this->getTempDir() . "/data:/data'"
             . " --volume '" . $this->getTempDir() . "/tmp:/tmp'"
             . " --memory '256m'"
-            . " --memory-swap '256m'"
             . " --net 'bridge'"
             . " --cpus '2'"
             . $deviceLimits
@@ -56,6 +55,14 @@ class ContainerTest extends BaseContainerTest
     {
         $container = $this->getContainer($this->getImageConfiguration(), [], [], false);
         self::assertContains(" --user \$(id -u):\$(id -g)", $container->getRunCommand("name"));
+    }
+
+    public function testRunCommandContainerWithoutSwap()
+    {
+        $imageConfiguration = $this->getImageConfiguration();
+        $imageConfiguration['features'] = ['no-swap'];
+        $container = $this->getContainer($imageConfiguration, [], [], false);
+        self::assertContains(" --memory-swap '256m'", $container->getRunCommand("name"));
     }
 
     public function testInspectCommand()

--- a/Tests/Runner/LimitsTest.php
+++ b/Tests/Runner/LimitsTest.php
@@ -97,18 +97,6 @@ class LimitsTest extends TestCase
         self::assertEquals(2, $limits->getCpuLimit($this->getImageMock()));
     }
 
-    public function testDeviceIOLimits()
-    {
-        $limits = new Limits(
-            new NullLogger(),
-            [],
-            [],
-            [],
-            []
-        );
-        self::assertEquals("50m", $limits->getDeviceIOLimits($this->getImageMock()));
-    }
-
     /**
      * @return Image
      */

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -1882,7 +1882,9 @@ class RunnerTest extends BaseRunnerTest
         ];
         $jobDefinition = new JobDefinition($configData, new Component($componentData), 'runner-configuration');
         $runner = $this->getRunner();
-        $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile);
+        $output = $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile);
+        self::assertCount(1, $output);
+        self::assertEquals("Script file /data/script.py\nScript finished", $output[0]->getProcessOutput());
     }
 
     public function swapFeatureProvider()

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -1577,7 +1577,7 @@ class RunnerTest extends BaseRunnerTest
         );
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable'));
     }
-    
+
     public function testPermissionsFailedWithoutContainerRootUserFeature()
     {
         $componentData = [
@@ -1851,4 +1851,46 @@ class RunnerTest extends BaseRunnerTest
             ]
         ], $job->getUsage());
     }
+
+    /**
+     * @dataProvider swapFeatureProvider
+     */
+    public function testExecutorSwap($features)
+    {
+        $this->clearConfigurations();
+        $usageFile = new NullUsageFile();
+        $component = new Components($this->getClient());
+        $configuration = new Configuration();
+        $configuration->setComponentId('keboola.docker-demo-sync');
+        $configuration->setName('Test configuration');
+        $configuration->setConfigurationId('runner-configuration');
+        $component->addConfiguration($configuration);
+        $componentData = [
+            'id' => 'keboola.docker-demo-sync',
+            'data' => [
+                'definition' => [
+                    'type' => 'aws-ecr',
+                    'uri' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/keboola.python-transformation',
+                ],
+            ],
+            'features' => $features
+        ];
+        $configData = [
+            'parameters' => [
+                'script' => [],
+            ],
+        ];
+        $jobDefinition = new JobDefinition($configData, new Component($componentData), 'runner-configuration');
+        $runner = $this->getRunner();
+        $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile);
+    }
+
+    public function swapFeatureProvider()
+    {
+        return [
+            [["no-swap"]],
+            [[]],
+        ];
+    }
+
 }

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -1892,5 +1892,4 @@ class RunnerTest extends BaseRunnerTest
             [[]],
         ];
     }
-
 }

--- a/src/Docker/Component.php
+++ b/src/Docker/Component.php
@@ -122,6 +122,14 @@ class Component
     }
 
     /**
+     * @return bool
+     */
+    public function hasNoSwap()
+    {
+        return in_array('no-swap', $this->features);
+    }
+
+    /**
      * Change type of component image
      * @param $type
      * @return Component

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -376,25 +376,6 @@ class Container
         }
     }
 
-    private function getDeviceLimits()
-    {
-        $process = new \Symfony\Component\Process\Process(
-            "lsblk --nodeps --output NAME --noheadings 2>/dev/null"
-        );
-        $process->mustRun();
-        $devices = array_filter(explode("\n", $process->getOutput()), function ($device) {
-            return !empty($device);
-        });
-        $deviceLimits = "";
-        foreach ($devices as $device) {
-            $deviceLimits .= " --device-write-bps " .
-                escapeshellarg("/dev/{$device}:{$this->limits->getDeviceIOLimits($this->getImage())}");
-            $deviceLimits .= " --device-read-bps " .
-                escapeshellarg("/dev/{$device}:{$this->limits->getDeviceIOLimits($this->getImage())}");
-        }
-        return $deviceLimits;
-    }
-
     /**
      * @param string $containerId
      * @return string
@@ -419,7 +400,6 @@ class Container
             . ($this->getImage()->getSourceComponent()->hasNoSwap() ? " --memory-swap " . escapeshellarg($this->limits->getMemorySwapLimit($this->getImage())) : "")
             . " --net " . escapeshellarg($this->limits->getNetworkLimit($this->getImage()))
             . " --cpus " . escapeshellarg($this->limits->getCpuLimit($this->getImage()))
-            . $this->getDeviceLimits()
             . $envs
             . $labels
             . " --name " . escapeshellarg($containerId)

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -416,7 +416,7 @@ class Container
         $command .= " --volume " . escapeshellarg($this->dataDir . ":/data")
             . " --volume " . escapeshellarg($this->tmpDir . ":/tmp")
             . " --memory " . escapeshellarg($this->limits->getMemoryLimit($this->getImage()))
-            . " --memory-swap " . escapeshellarg($this->limits->getMemorySwapLimit($this->getImage()))
+            . ($this->getImage()->getSourceComponent()->hasNoSwap() ? " --memory-swap " . escapeshellarg($this->limits->getMemorySwapLimit($this->getImage())) : "")
             . " --net " . escapeshellarg($this->limits->getNetworkLimit($this->getImage()))
             . " --cpus " . escapeshellarg($this->limits->getCpuLimit($this->getImage()))
             . $this->getDeviceLimits()

--- a/src/Docker/Runner/Limits.php
+++ b/src/Docker/Runner/Limits.php
@@ -91,11 +91,6 @@ class Limits
         return min($instance, $project);
     }
 
-    public function getDeviceIOLimits(Image $image)
-    {
-        return '50m';
-    }
-
     /**
      * @return Range[]
      */


### PR DESCRIPTION
- added `no-swap` feature to revert the new behavior
- removed device io limits, as they were not working properly (https://github.com/keboola/syrup-router/issues/118)

FIXES https://github.com/keboola/syrup-router/issues/118