### PR TITLE
longer exception messages

### DIFF
--- a/Tests/Docker/Container/LoggerTest.php
+++ b/Tests/Docker/Container/LoggerTest.php
@@ -561,8 +561,8 @@ class LoggerTest extends BaseContainerTest
             $container->run();
         } catch (UserException $e) {
             self::assertContains('message to stderr', $e->getMessage());
-            self::assertGreaterThan(250, strlen($e->getMessage()));
-            self::assertLessThan(280, strlen($e->getMessage()));
+            self::assertGreaterThan(4000, strlen($e->getMessage()));
+            self::assertLessThan(4050, strlen($e->getMessage()));
             self::assertContains('message to stderr', $e->getData()['errorOutput']);
             self::assertContains('message to stdout', $e->getData()['output']);
         }

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -324,9 +324,9 @@ class Container
             $message = "No error message.";
         }
 
-        // make the exception message very short
-        if (mb_strlen($message) > 255) {
-            $message = mb_substr($message, 0, 125) . " ... " . mb_substr($message, -125);
+        // make the exception message reasonably short
+        if (mb_strlen($message) > 4000) {
+            $message = mb_substr($message, 0, 2000) . " ... " . mb_substr($message, -2000);
         }
 
         // put the whole message to exception data, but make sure not use too much memory


### PR DESCRIPTION
fixes #334 

limit jsem dal na ~4000 znaku, protoze nemuzu uplne vyloucit, ze tam by se projevilo oriznuti na 8000 znaku v PT,  4000 pro samotny messagy by melo znamenat, ze se do 8000 vejde s rezervou i JSON
i tak je to vic jak 10x vic nez soucasna delka, takze by to melo vyresit #334 a dalsi experimenty s limitem zprav bych nechal na https://github.com/keboola/docker-runner-jobs
