### PR TITLE
fix: user exception

### DIFF
--- a/src/Exception/ApplicationException.php
+++ b/src/Exception/ApplicationException.php
@@ -4,19 +4,4 @@ namespace Keboola\DockerBundle\Exception;
 
 class ApplicationException extends \Keboola\Syrup\Exception\ApplicationException
 {
-    protected $data = array();
-
-    public function __construct($message, $previous = null, array $data = [])
-    {
-        parent::__construct($message, $previous, $data);
-        $this->data = $data;
-    }
-
-    /**
-     * @return array
-     */
-    public function getData()
-    {
-        return $this->data;
-    }
 }

--- a/src/Exception/UserException.php
+++ b/src/Exception/UserException.php
@@ -2,6 +2,6 @@
 
 namespace Keboola\DockerBundle\Exception;
 
-class UserException extends ApplicationException
+class UserException extends \Keboola\Syrup\Exception\UserException
 {
 }


### PR DESCRIPTION
fixes #354 

nakonec to bylo tím, že docker runnerovej `UserException` dědil z docker runnerovýho `ApplicationException` (a ten už dědil syrupovej `ApplicationException`). 

- změnil jsem dědičnost `\Keboola\DockerBundle\Exception\UserException`  z `\Keboola\DockerBundle\Exception\ApplicationException` na `\Keboola\Syrup\Exception\UserException`
- v `\Keboola\DockerBundle\Exception\ApplicationException` jsem vymazal celej vnitřek, protože už ho `\Keboola\Syrup\Exception\ApplicationException` má