### PR TITLE
Revert "feat: catch logged events from storage api client"

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -39,4 +39,4 @@ services:
 
     syrup.storage_api:
         class: Keboola\DockerBundle\Service\StorageApiService
-        arguments: ["@request_stack", "%storage_api.url%", "@logger"]
+        arguments: ["@request_stack", "%storage_api.url%"]

--- a/composer.lock
+++ b/composer.lock
@@ -2100,16 +2100,16 @@
         },
         {
             "name": "keboola/storage-api-client",
-            "version": "10.3.0",
+            "version": "10.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/storage-api-php-client.git",
-                "reference": "6b01f17d008a1a6161306ba24609252024e928b8"
+                "reference": "8d658203a944623836a86b4247c5100c41365e4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/storage-api-php-client/zipball/6b01f17d008a1a6161306ba24609252024e928b8",
-                "reference": "6b01f17d008a1a6161306ba24609252024e928b8",
+                "url": "https://api.github.com/repos/keboola/storage-api-php-client/zipball/8d658203a944623836a86b4247c5100c41365e4e",
+                "reference": "8d658203a944623836a86b4247c5100c41365e4e",
                 "shasum": ""
             },
             "require": {
@@ -2143,7 +2143,7 @@
             ],
             "description": "Keboola Storage API PHP CLient",
             "homepage": "http://keboola.com",
-            "time": "2018-11-29T12:17:33+00:00"
+            "time": "2018-05-16T16:53:42+00:00"
         },
         {
             "name": "keboola/syrup",

--- a/src/Service/StorageApiService.php
+++ b/src/Service/StorageApiService.php
@@ -3,23 +3,10 @@
 namespace Keboola\DockerBundle\Service;
 
 use Keboola\StorageApi\Client;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class StorageApiService extends \Keboola\Syrup\Service\StorageApi\StorageApiService
 {
     private $fasterPollingClient = null;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    public function __construct(RequestStack $requestStack, $storageApiUrl = 'https://connection.keboola.com', LoggerInterface $logger = null)
-    {
-        parent::__construct($requestStack, $storageApiUrl);
-        $this->logger = $logger;
-    }
 
     /**
      * @return \Closure
@@ -51,8 +38,7 @@ class StorageApiService extends \Keboola\Syrup\Service\StorageApi\StorageApiServ
                     'url' => $client->getApiUrl(),
                     'userAgent' => $client->getUserAgent(),
                     'backoffMaxTries' => $client->getBackoffMaxTries(),
-                    'jobPollRetryDelay' => self::getStepPollDelayFunction(),
-                    'logger' => $this->logger
+                    'jobPollRetryDelay' => self::getStepPollDelayFunction()
                 ]
             );
             if ($client->getRunId()) {


### PR DESCRIPTION
Reverts keboola/docker-bundle#367

Circular reference detected for service "syrup.storage_api", path: "syrup.listener.exception -> syrup.storage_api -> logger -> syrup.monolog.sapi_handler".  

https://jenkins.keboola.com/view/Docker%20Runner/job/PHPUnit%20-%20docker-bundle/707/console

nechapu to, ale je to rozbity