### PR TITLE
update output mapping take2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "keboola/oauth-v2-php-client": "^2.2",
         "keboola/gelf-server": "^2.0",
         "keboola/input-mapping": "^6.1",
-        "keboola/output-mapping": "^6.2",
+        "keboola/output-mapping": "^8.0",
         "symfony/validator": "^2.8|^4.1",
         "vkartaviy/retry": "^0.2",
         "keboola/object-encryptor": "^0.1"


### PR DESCRIPTION
refactor: removed support for parallel-output-mapping-load feature
feat: deferred loads are now the only behavior
