### PR TITLE
update output mapping take4

### DIFF
--- a/Tests/Runner/DataLoaderMetadataTest.php
+++ b/Tests/Runner/DataLoaderMetadataTest.php
@@ -29,7 +29,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
             "id,text,row_number\n1,test,1\n1,test,2\n1,test,3"
         );
         $dataLoader = $this->getDataLoader([]);
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
 
         $bucketMetadata = $this->metadata->listBucketMetadata('in.c-docker-demo-testConfig');
         $expectedBucketMetadata = [
@@ -51,7 +52,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
 
         // let's run the data loader again.
         // This time the tables should receive 'update' metadata
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
         $tableMetadata = $this->metadata->listTableMetadata('in.c-docker-demo-testConfig.sliced');
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.component.id'] = 'docker-demo';
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.configuration.id'] = 'testConfig';
@@ -67,7 +69,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
             "id,text,row_number\n1,test,1\n1,test,2\n1,test,3"
         );
         $dataLoader = $this->getDataLoader([], 'testRow');
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
 
         $bucketMetadata = $this->metadata->listBucketMetadata('in.c-docker-demo-testConfig');
         $expectedBucketMetadata = [
@@ -91,7 +94,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
 
         // let's run the data loader again.
         // This time the tables should receive 'update' metadata
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
 
         $tableMetadata = $this->metadata->listTableMetadata('in.c-docker-demo-testConfig.sliced');
         $expectedTableMetadata['system']['KBC.lastUpdatedBy.component.id'] = 'docker-demo';
@@ -158,7 +162,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
             ],
         ];
         $dataLoader = $this->getDataLoader($config);
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
         $tableMetadata = $this->metadata->listTableMetadata('in.c-docker-demo-testConfig.sliced');
         $expectedTableMetadata = [
             'system' => [
@@ -225,7 +230,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
         ';
         $fs->dumpFile($this->workingDir->getDataDir() . '/out/tables/sliced.csv.manifest', $manifest);
         $dataLoader = $this->getDataLoader([]);
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
 
         $tableMetadata = $this->metadata->listTableMetadata('in.c-docker-demo-testConfig.sliced');
         $expectedTableMetadata = [
@@ -296,7 +302,8 @@ class DataLoaderMetadataTest extends BaseDataLoaderTest
         ];
 
         $dataLoader = $this->getDataLoader($config);
-        $dataLoader->storeOutput();
+        $tableQueue = $dataLoader->storeOutput();
+        $tableQueue->waitForAll();
         $tableMetadata = $this->metadata->listTableMetadata('in.c-docker-demo-testConfig.sliced');
         $expectedTableMetadata = [
             'system' => [

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -483,201 +483,7 @@ class RunnerTest extends BaseRunnerTest
         );
 
         self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.sliced'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 0 storage jobs'));
-        $this->clearBuckets();
-    }
-
-    public function testExecutorDeferredLoad()
-    {
-        $this->createBuckets();
-        $temp = new Temp();
-        $temp->initRunFolder();
-        $csv = new CsvFile($temp->getTmpFolder() . '/upload.csv');
-        $csv->writeRow(['id', 'text']);
-        $csv->writeRow(['test', 'test']);
-        $this->getClient()->createTableAsync('in.c-runner-test', 'test', $csv);
-        $csv = new CsvFile($temp->getTmpFolder() . '/upload2.csv');
-        $csv->writeRow(['id2', 'text2']);
-        $csv->writeRow(['test2', 'test2']);
-        $this->getClient()->createTableAsync('in.c-runner-test', 'test2', $csv);
-
-        unset($csv);
-
-        $client = new Client(['token' => STORAGE_API_TOKEN, 'url' => STORAGE_API_URL]);
-        $componentData = [
-            'id' => 'keboola.docker-demo-sync',
-            'data' => [
-                'definition' => [
-                    'type' => 'aws-ecr',
-                    'uri' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/keboola.python-transformation',
-                ],
-                'default_bucket' => true,
-                'default_bucket_stage' => 'out',
-            ],
-        ];
-        $tokenInfo = $client->verifyToken();
-        $tokenInfo['owner']['features'] = ['parallel-output-mapping-load'];
-        $clientMock = self::getMockBuilder(Client::class)
-            ->setConstructorArgs([[
-                'url' => STORAGE_API_URL,
-                'token' => STORAGE_API_TOKEN,
-            ]])
-            ->setMethods(['verifyToken'])
-            ->getMock();
-        $clientMock->expects(self::any())
-            ->method('verifyToken')
-            ->will(self::returnValue($tokenInfo));
-        $this->setClientMock($clientMock);
-
-        $configData = [
-            'storage' => [
-                'input' => [
-                    'tables' => [
-                        [
-                            'source' => 'in.c-runner-test.test',
-                            'destination' => 'source.csv',
-                        ],
-                        [
-                            'source' => 'in.c-runner-test.test2',
-                            'destination' => 'source2.csv',
-                        ],
-                    ],
-                ],
-            ],
-            'parameters' => [
-                'script' => [
-                    'from shutil import copyfile',
-                    'copyfile("/data/in/tables/source.csv", "/data/out/tables/table1.csv")',
-                    'copyfile("/data/in/tables/source2.csv", "/data/out/tables/table2.csv")',
-                ]
-            ]
-        ];
-        $runner = $this->getRunner();
-        $runner->run(
-            $this->prepareJobDefinitions(
-                $componentData,
-                'runner-configuration',
-                $configData,
-                []
-            ),
-            'run',
-            'run',
-            '1234567',
-            new NullUsageFile()
-        );
-
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 1)'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 storage jobs'));
-        self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.table1'));
-        self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.table2'));
-        $this->clearBuckets();
-    }
-
-    public function testExecutorDeferredLoadConfigRows()
-    {
-        $this->createBuckets();
-        $temp = new Temp();
-        $temp->initRunFolder();
-        $csv = new CsvFile($temp->getTmpFolder() . '/upload.csv');
-        $csv->writeRow(['id', 'text']);
-        $csv->writeRow(['test', 'test']);
-        $this->getClient()->createTableAsync('in.c-runner-test', 'test', $csv);
-        $csv = new CsvFile($temp->getTmpFolder() . '/upload2.csv');
-        $csv->writeRow(['id2', 'text2']);
-        $csv->writeRow(['test2', 'test2']);
-        $this->getClient()->createTableAsync('in.c-runner-test', 'test2', $csv);
-
-        unset($csv);
-
-        $client = new Client(['token' => STORAGE_API_TOKEN, 'url' => STORAGE_API_URL]);
-        $componentData = [
-            'id' => 'keboola.docker-demo-sync',
-            'data' => [
-                'definition' => [
-                    'type' => 'aws-ecr',
-                    'uri' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/keboola.python-transformation',
-                ],
-                'default_bucket' => true,
-                'default_bucket_stage' => 'out',
-            ],
-        ];
-        $tokenInfo = $client->verifyToken();
-        $tokenInfo['owner']['features'] = ['parallel-output-mapping-load'];
-        $clientMock = self::getMockBuilder(Client::class)
-            ->setConstructorArgs([[
-                'url' => STORAGE_API_URL,
-                'token' => STORAGE_API_TOKEN,
-            ]])
-            ->setMethods(['verifyToken'])
-            ->getMock();
-        $clientMock->expects(self::any())
-            ->method('verifyToken')
-            ->will(self::returnValue($tokenInfo));
-        $this->setClientMock($clientMock);
-
-        $configData1 = [
-            'storage' => [
-                'input' => [
-                    'tables' => [
-                        [
-                            'source' => 'in.c-runner-test.test',
-                            'destination' => 'source.csv',
-                        ],
-                    ],
-                ],
-            ],
-            'parameters' => [
-                'script' => [
-                    'from shutil import copyfile',
-                    'copyfile("/data/in/tables/source.csv", "/data/out/tables/table1.csv")',
-                ]
-            ]
-        ];
-        $configData2 = [
-            'storage' => [
-                'input' => [
-                    'tables' => [
-                        [
-                            'source' => 'in.c-runner-test.test2',
-                            'destination' => 'source2.csv',
-                        ],
-                    ],
-                ],
-            ],
-            'parameters' => [
-                'script' => [
-                    'from shutil import copyfile',
-                    'copyfile("/data/in/tables/source2.csv", "/data/out/tables/table2.csv")',
-                ]
-            ]
-        ];
-        $runner = $this->getRunner();
-        $runner->run(
-            array_merge(
-                $this->prepareJobDefinitions(
-                    $componentData,
-                    'runner-configuration1',
-                    $configData1,
-                    []
-                ),
-                $this->prepareJobDefinitions(
-                    $componentData,
-                    'runner-configuration2',
-                    $configData2,
-                    []
-                )
-            ),
-            'run',
-            'run',
-            '1234567',
-            new NullUsageFile()
-        );
-
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 storage jobs'));
-        self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.table1'));
-        self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.table2'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 1 storage jobs'));
         $this->clearBuckets();
     }
 
@@ -889,23 +695,15 @@ class RunnerTest extends BaseRunnerTest
         self::assertEquals('fooBar1', $row1['state']['bazRow1']);
         self::assertArrayHasKey('bazRow2', $row2['state']);
         self::assertEquals('fooBar2', $row2['state']['bazRow2']);
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 storage jobs'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
         $this->clearConfigurations();
     }
 
-    public function outputMappingFeatureProvider()
-    {
-        return [
-            [[]],
-            [['parallel-output-mapping-load']],
-        ];
-    }
-
-    /**
-     * @dataProvider outputMappingFeatureProvider
-     */
-    public function testExecutorStoreStateRowsOutputMappingEarlyError(array $features)
+    public function testExecutorStoreStateRowsOutputMappingEarlyError()
     {
         $this->clearBuckets();
         $this->clearConfigurations();
@@ -944,19 +742,6 @@ class RunnerTest extends BaseRunnerTest
                 ],
             ],
         ];
-        $tokenInfo = $this->client->verifyToken();
-        $tokenInfo['owner']['features'] = $features;
-        $clientMock = self::getMockBuilder(Client::class)
-            ->setConstructorArgs([[
-                'url' => STORAGE_API_URL,
-                'token' => STORAGE_API_TOKEN,
-            ]])
-            ->setMethods(['verifyToken'])
-            ->getMock();
-        $clientMock->expects(self::any())
-            ->method('verifyToken')
-            ->will(self::returnValue($tokenInfo));
-        $this->setClientMock($clientMock);
 
         $runner = $this->getRunner();
         try {
@@ -992,7 +777,7 @@ class RunnerTest extends BaseRunnerTest
         $this->clearConfigurations();
     }
 
-    public function testExecutorStoreStateRowsOutputMappingDeferredLateError()
+    public function testExecutorStoreStateRowsOutputMappingLateError()
     {
         $this->clearBuckets();
         $this->clearConfigurations();
@@ -1049,19 +834,6 @@ class RunnerTest extends BaseRunnerTest
                 ],
             ],
         ];
-        $tokenInfo = $this->client->verifyToken();
-        $tokenInfo['owner']['features'] = ['parallel-output-mapping-load'];
-        $clientMock = self::getMockBuilder(Client::class)
-            ->setConstructorArgs([[
-                'url' => STORAGE_API_URL,
-                'token' => STORAGE_API_TOKEN,
-            ]])
-            ->setMethods(['verifyToken'])
-            ->getMock();
-        $clientMock->expects(self::any())
-            ->method('verifyToken')
-            ->will(self::returnValue($tokenInfo));
-        $this->setClientMock($clientMock);
 
         $runner = $this->getRunner();
         try {

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -483,7 +483,7 @@ class RunnerTest extends BaseRunnerTest
         );
 
         self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.sliced'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 1 storage jobs'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 1 Storage batches'));
         $this->clearBuckets();
     }
 
@@ -697,7 +697,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertEquals('fooBar2', $row2['state']['bazRow2']);
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 storage jobs'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 Storage batches'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
         $this->clearConfigurations();
@@ -849,8 +849,9 @@ class RunnerTest extends BaseRunnerTest
             );
         } catch (UserException $e) {
             self::assertContains(
-                'Failed to process output mapping: Load error: odbc_execute(): ' .
-                'SQL error: Number of columns in file (3) does not match that of the corresponding table (2)',
+                'Failed to process output mapping: Failed to load table "out.c-runner-test.my-table-1": ' .
+                'Load error: odbc_execute(): SQL error: Number of columns in file (3) does not match that of the ' .
+                'corresponding table (2)',
                 $e->getMessage()
             );
         }
@@ -875,7 +876,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertArrayNotHasKey('bazRow2', $row2['state']);
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 storage jobs'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 Storage batches'));
         $this->clearConfigurations();
     }
 

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -483,7 +483,7 @@ class RunnerTest extends BaseRunnerTest
         );
 
         self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.sliced'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 1 Storage batches'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
         $this->clearBuckets();
     }
 
@@ -697,7 +697,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertEquals('fooBar2', $row2['state']['bazRow2']);
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 Storage batches'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
         $this->clearConfigurations();
@@ -876,7 +876,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertArrayNotHasKey('bazRow2', $row2['state']);
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
-        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for 2 Storage batches'));
+        self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
         $this->clearConfigurations();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "keboola/oauth-v2-php-client": "^2.2",
         "keboola/gelf-server": "^2.0",
         "keboola/input-mapping": "^6.1",
-        "keboola/output-mapping": "^6.2",
+        "keboola/output-mapping": "^7.0",
         "symfony/validator": "^2.8|^4.1",
         "vkartaviy/retry": "^0.2",
         "keboola/object-encryptor": "^0.1"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "keboola/oauth-v2-php-client": "^2.2",
         "keboola/gelf-server": "^2.0",
         "keboola/input-mapping": "^6.1",
-        "keboola/output-mapping": "dev-odin-jobs-2",
+        "keboola/output-mapping": "^8.0",
         "symfony/validator": "^2.8|^4.1",
         "vkartaviy/retry": "^0.2",
         "keboola/object-encryptor": "^0.1"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "keboola/oauth-v2-php-client": "^2.2",
         "keboola/gelf-server": "^2.0",
         "keboola/input-mapping": "^6.1",
-        "keboola/output-mapping": "^7.0",
+        "keboola/output-mapping": "dev-odin-jobs-2",
         "symfony/validator": "^2.8|^4.1",
         "vkartaviy/retry": "^0.2",
         "keboola/object-encryptor": "^0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5cbd3c1ce0b7bfedca3a7155ddb6355",
+    "content-hash": "4a210b6db2d1db4ebaed21889774c80d",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.86.1",
+            "version": "3.86.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "217f783754b803b95eea220308ca7cf046ead832"
+                "reference": "50224232ac7a4e2a6fa4ebbe0281e5b7503acf76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/217f783754b803b95eea220308ca7cf046ead832",
-                "reference": "217f783754b803b95eea220308ca7cf046ead832",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/50224232ac7a4e2a6fa4ebbe0281e5b7503acf76",
+                "reference": "50224232ac7a4e2a6fa4ebbe0281e5b7503acf76",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-01-17T23:11:37+00:00"
+            "time": "2019-01-18T21:10:44+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -1949,17 +1949,17 @@
         },
         {
             "name": "keboola/output-mapping",
-            "version": "7.0.2",
+            "version": "dev-odin-jobs-2",
             "target-dir": "Keboola/OutputMapping",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/output-mapping.git",
-                "reference": "f850dc6474c8f1e51c55aa767e6b6470dc83ddd8"
+                "reference": "12a81264a0678bd751782509f579a857c5ceb339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/f850dc6474c8f1e51c55aa767e6b6470dc83ddd8",
-                "reference": "f850dc6474c8f1e51c55aa767e6b6470dc83ddd8",
+                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/12a81264a0678bd751782509f579a857c5ceb339",
+                "reference": "12a81264a0678bd751782509f579a857c5ceb339",
                 "shasum": ""
             },
             "require": {
@@ -1995,7 +1995,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
-            "time": "2019-01-18T09:57:45+00:00"
+            "time": "2019-01-19T10:09:31+00:00"
         },
         {
             "name": "keboola/php-encryption",
@@ -6455,7 +6455,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "keboola/output-mapping": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a210b6db2d1db4ebaed21889774c80d",
+    "content-hash": "084d5154fb486bbfe5d30b99b7136cde",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1949,17 +1949,17 @@
         },
         {
             "name": "keboola/output-mapping",
-            "version": "dev-odin-jobs-2",
+            "version": "8.0.0",
             "target-dir": "Keboola/OutputMapping",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/output-mapping.git",
-                "reference": "12a81264a0678bd751782509f579a857c5ceb339"
+                "reference": "cade3fe86b653bb8e6b1c432047cb04e75180cc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/12a81264a0678bd751782509f579a857c5ceb339",
-                "reference": "12a81264a0678bd751782509f579a857c5ceb339",
+                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/cade3fe86b653bb8e6b1c432047cb04e75180cc1",
+                "reference": "cade3fe86b653bb8e6b1c432047cb04e75180cc1",
                 "shasum": ""
             },
             "require": {
@@ -1995,7 +1995,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
-            "time": "2019-01-19T10:09:31+00:00"
+            "time": "2019-01-21T17:16:32+00:00"
         },
         {
             "name": "keboola/php-encryption",
@@ -6455,9 +6455,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "keboola/output-mapping": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b3df226cef96fce8824afe32fcfaa8b",
+    "content-hash": "f5cbd3c1ce0b7bfedca3a7155ddb6355",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.81.1",
+            "version": "3.86.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "02a3ea09dd846c2d3bb923d6c91902f08c5bf2af"
+                "reference": "217f783754b803b95eea220308ca7cf046ead832"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/02a3ea09dd846c2d3bb923d6c91902f08c5bf2af",
-                "reference": "02a3ea09dd846c2d3bb923d6c91902f08c5bf2af",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/217f783754b803b95eea220308ca7cf046ead832",
+                "reference": "217f783754b803b95eea220308ca7cf046ead832",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-12-06T20:10:37+00:00"
+            "time": "2019-01-17T23:11:37+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -559,16 +559,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "82d2c63cd09acbde2332f55d9aa7b28aefe4983d"
+                "reference": "98551d71f515692c2278073e0d483763ac70b341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/82d2c63cd09acbde2332f55d9aa7b28aefe4983d",
-                "reference": "82d2c63cd09acbde2332f55d9aa7b28aefe4983d",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/98551d71f515692c2278073e0d483763ac70b341",
+                "reference": "98551d71f515692c2278073e0d483763ac70b341",
                 "shasum": ""
             },
             "require": {
@@ -640,7 +640,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2018-11-30T13:53:17+00:00"
+            "time": "2019-01-07T15:31:08+00:00"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -1048,12 +1048,12 @@
             "version": "v2.5.14",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/doctrine2.git",
+                "url": "https://github.com/doctrine/orm.git",
                 "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/810a7baf81462a5ddf10e8baa8cb94b6eec02754",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/810a7baf81462a5ddf10e8baa8cb94b6eec02754",
                 "reference": "810a7baf81462a5ddf10e8baa8cb94b6eec02754",
                 "shasum": ""
             },
@@ -1224,16 +1224,16 @@
         },
         {
             "name": "graylog2/gelf-php",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bzikarsky/gelf-php.git",
-                "reference": "2a1c3b8d77d6c301b844715fd15d971ec075947d"
+                "reference": "2344540be1db5e882990d527588649e065efbde0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bzikarsky/gelf-php/zipball/2a1c3b8d77d6c301b844715fd15d971ec075947d",
-                "reference": "2a1c3b8d77d6c301b844715fd15d971ec075947d",
+                "url": "https://api.github.com/repos/bzikarsky/gelf-php/zipball/2344540be1db5e882990d527588649e065efbde0",
+                "reference": "2344540be1db5e882990d527588649e065efbde0",
                 "shasum": ""
             },
             "require": {
@@ -1274,7 +1274,7 @@
                 }
             ],
             "description": "A php implementation to send log-messages to a GELF compatible backend like Graylog2.",
-            "time": "2018-11-13T09:33:26+00:00"
+            "time": "2018-12-17T07:48:16+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -1949,23 +1949,23 @@
         },
         {
             "name": "keboola/output-mapping",
-            "version": "6.2.1",
+            "version": "7.0.2",
             "target-dir": "Keboola/OutputMapping",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/output-mapping.git",
-                "reference": "32016b17b7abf075db3ca0026cbf0b2148952d6f"
+                "reference": "f850dc6474c8f1e51c55aa767e6b6470dc83ddd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/32016b17b7abf075db3ca0026cbf0b2148952d6f",
-                "reference": "32016b17b7abf075db3ca0026cbf0b2148952d6f",
+                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/f850dc6474c8f1e51c55aa767e6b6470dc83ddd8",
+                "reference": "f850dc6474c8f1e51c55aa767e6b6470dc83ddd8",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^6.2",
                 "keboola/input-mapping": "^6.0",
-                "keboola/storage-api-client": "^10.0",
+                "keboola/sanitizer": "^0.1",
                 "monolog/monolog": "^1.22",
                 "symfony/config": "^2.8|^4.1",
                 "symfony/finder": "^2.8|^4.1",
@@ -1995,7 +1995,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
-            "time": "2018-12-03T15:31:30+00:00"
+            "time": "2019-01-18T09:57:45+00:00"
         },
         {
             "name": "keboola/php-encryption",
@@ -2158,6 +2158,47 @@
                 "utility"
             ],
             "time": "2018-04-11T14:40:53+00:00"
+        },
+        {
+            "name": "keboola/sanitizer",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/keboola/sanitizer.git",
+                "reference": "6edda00cd177409a33f180b8f12bdad89bf893c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/keboola/sanitizer/zipball/6edda00cd177409a33f180b8f12bdad89bf893c5",
+                "reference": "6edda00cd177409a33f180b8f12bdad89bf893c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phpunit/phpunit": "^5.7",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Keboola\\Utils\\Sanitizer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Keboola",
+                    "email": "devel@keboola.com"
+                }
+            ],
+            "description": "Column name sanitizer",
+            "time": "2019-01-11T10:21:17+00:00"
         },
         {
             "name": "keboola/storage-api-client",
@@ -2612,16 +2653,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.17",
+            "version": "v2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d"
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/29af24f25bab834fcbb38ad2a69fa93b867e070d",
-                "reference": "29af24f25bab834fcbb38ad2a69fa93b867e070d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
+                "reference": "0a58ef6e3146256cc3dc7cc393927bcc7d1b72db",
                 "shasum": ""
             },
             "require": {
@@ -2657,7 +2698,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-04T16:31:37+00:00"
+            "time": "2019-01-03T20:59:08+00:00"
         },
         {
             "name": "phpseclib/mcrypt_compat",
@@ -2710,16 +2751,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.12",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "8814dc7841db159daed0b32c2b08fb7e03c6afe7"
+                "reference": "42603ce3f42a27f7e14e54feab95db7b680ad473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/8814dc7841db159daed0b32c2b08fb7e03c6afe7",
-                "reference": "8814dc7841db159daed0b32c2b08fb7e03c6afe7",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/42603ce3f42a27f7e14e54feab95db7b680ad473",
+                "reference": "42603ce3f42a27f7e14e54feab95db7b680ad473",
                 "shasum": ""
             },
             "require": {
@@ -2798,7 +2839,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2018-11-04T05:45:48+00:00"
+            "time": "2018-12-16T17:45:25+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -3219,16 +3260,16 @@
         },
         {
             "name": "react/promise",
-            "version": "v2.7.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "f4edc2581617431aea50430749db55cc3fc031b3"
+                "reference": "31ffa96f8d2ed0341a57848cbb84d88b89dd664d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f4edc2581617431aea50430749db55cc3fc031b3",
-                "reference": "f4edc2581617431aea50430749db55cc3fc031b3",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/31ffa96f8d2ed0341a57848cbb84d88b89dd664d",
+                "reference": "31ffa96f8d2ed0341a57848cbb84d88b89dd664d",
                 "shasum": ""
             },
             "require": {
@@ -3261,7 +3302,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2018-06-13T15:59:06+00:00"
+            "time": "2019-01-07T21:25:54+00:00"
         },
         {
             "name": "react/promise-timer",
@@ -3365,16 +3406,16 @@
         },
         {
             "name": "react/stream",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/stream.git",
-                "reference": "fdd0140f42805d65bf9687636503db0b326d2244"
+                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/fdd0140f42805d65bf9687636503db0b326d2244",
-                "reference": "fdd0140f42805d65bf9687636503db0b326d2244",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/50426855f7a77ddf43b9266c22320df5bf6c6ce6",
+                "reference": "50426855f7a77ddf43b9266c22320df5bf6c6ce6",
                 "shasum": ""
             },
             "require": {
@@ -3407,7 +3448,7 @@
                 "stream",
                 "writable"
             ],
-            "time": "2018-07-11T14:38:16+00:00"
+            "time": "2019-01-01T16:15:09+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -3638,16 +3679,16 @@
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v5.0.1",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "9ea927417c949039a9cfb0d92af76fd1c538d9e9"
+                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/9ea927417c949039a9cfb0d92af76fd1c538d9e9",
-                "reference": "9ea927417c949039a9cfb0d92af76fd1c538d9e9",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
+                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
                 "shasum": ""
             },
             "require": {
@@ -3680,7 +3721,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2018-10-16T10:30:44+00:00"
+            "time": "2018-12-19T17:14:59+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -4641,31 +4682,31 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.35.4",
+            "version": "v1.37.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "7e081e98378a1e78c29cc9eba4aefa5d78a05d2a"
+                "reference": "66be9366c76cbf23e82e7171d47cbfa54a057a62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/7e081e98378a1e78c29cc9eba4aefa5d78a05d2a",
-                "reference": "7e081e98378a1e78c29cc9eba4aefa5d78a05d2a",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/66be9366c76cbf23e82e7171d47cbfa54a057a62",
+                "reference": "66be9366c76cbf23e82e7171d47cbfa54a057a62",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=5.4.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.3"
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.35-dev"
+                    "dev-master": "1.37-dev"
                 }
             },
             "autoload": {
@@ -4703,7 +4744,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2018-07-13T07:12:17+00:00"
+            "time": "2019-01-14T14:59:29+00:00"
         },
         {
             "name": "vkartaviy/retry",
@@ -5121,7 +5162,7 @@
             ],
             "authors": [
                 {
-                    "name": "Padraic Brady",
+                    "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
                     "homepage": "http://blog.astrumfutura.com"
                 }
@@ -6311,16 +6352,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
-                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
                 "shasum": ""
             },
             "require": {
@@ -6358,24 +6399,25 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-09-23T23:08:17+00:00"
+            "time": "2018-12-19T23:57:18+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -6408,7 +6450,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -27,6 +27,7 @@ use Keboola\DockerBundle\Exception\UserException;
 use Keboola\DockerBundle\Service\LoggersService;
 use Keboola\OAuthV2Api\Credentials;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
+use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
@@ -352,10 +353,11 @@ class Runner
                 $tableQueues[] = $output->getTableQueue();
             }
         }
-        $this->loggersService->getLog()->info(sprintf('Waiting for %s Storage batches.', count($tableQueues)));
-        foreach ($tableQueues as $job) {
+        $this->loggersService->getLog()->info('Waiting for Storage jobs to finish.');
+        /** @var LoadTableQueue $tableQueue */
+        foreach ($tableQueues as $tableQueue) {
             try {
-                $job->waitForAll();
+                $tableQueue->waitForAll();
             } catch (InvalidOutputException $e) {
                 throw new UserException('Failed to process output mapping: ' . $e->getMessage(), $e);
             }

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -345,15 +345,15 @@ class Runner
 
     private function waitForStorageJobs(array $outputs)
     {
-        $jobs = [];
+        $tableQueues = [];
         foreach ($outputs as $output) {
             /** @var Output $output */
-            if ($output->getStorageJob()) {
-                $jobs[] = $output->getStorageJob();
+            if ($output->getTableQueue()) {
+                $tableQueues[] = $output->getTableQueue();
             }
         }
-        $this->loggersService->getLog()->info(sprintf('Waiting for %s Storage jobs.', count($jobs)));
-        foreach ($jobs as $job) {
+        $this->loggersService->getLog()->info(sprintf('Waiting for %s Storage batches.', count($tableQueues)));
+        foreach ($tableQueues as $job) {
             try {
                 $job->waitForAll();
             } catch (InvalidOutputException $e) {
@@ -390,8 +390,8 @@ class Runner
         if ($mode === self::MODE_DEBUG) {
             $dataLoader->storeDataArchive('stage_output', [self::MODE_DEBUG, $component->getId(), 'RowId:' . $rowId, 'JobId:' . $jobId]);
         } else {
-            $job = $dataLoader->storeOutput();
-            $output->setStorageJob($job);
+            $tableQueue = $dataLoader->storeOutput();
+            $output->setTableQueue($tableQueue);
         }
 
         // finalize

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -137,10 +137,6 @@ class DataLoader implements DataLoaderInterface
 
         $writer = new Writer($this->storageClient, $this->logger);
         $writer->setFormat($this->component->getConfigurationFormat());
-
-        $features = empty($this->storageClient->verifyToken()['owner']['features']) ? [] : $this->storageClient->verifyToken()['owner']['features'];
-        $deferred = in_array('parallel-output-mapping-load', $features);
-
         $outputTablesConfig = [];
         $outputFilesConfig = [];
 
@@ -174,7 +170,7 @@ class DataLoader implements DataLoaderInterface
         }
 
         try {
-            $jobIds = $writer->uploadTables($this->dataDirectory . "/out/tables", $uploadTablesOptions, $systemMetadata, $deferred);
+            $jobIds = $writer->uploadTables($this->dataDirectory . "/out/tables", $uploadTablesOptions, $systemMetadata);
             $writer->uploadFiles($this->dataDirectory . "/out/files", ["mapping" => $outputFilesConfig]);
 
             if (isset($this->storageConfig["input"]["files"])) {

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -170,14 +170,14 @@ class DataLoader implements DataLoaderInterface
         }
 
         try {
-            $jobIds = $writer->uploadTables($this->dataDirectory . "/out/tables", $uploadTablesOptions, $systemMetadata);
+            $tableQueue = $writer->uploadTables($this->dataDirectory . "/out/tables", $uploadTablesOptions, $systemMetadata);
             $writer->uploadFiles($this->dataDirectory . "/out/files", ["mapping" => $outputFilesConfig]);
 
             if (isset($this->storageConfig["input"]["files"])) {
                 // tag input files
                 $writer->tagFiles($this->storageConfig["input"]["files"]);
             }
-            return $jobIds;
+            return $tableQueue;
         } catch (InvalidOutputException $ex) {
             throw new UserException($ex->getMessage(), $ex);
         }

--- a/src/Docker/Runner/DataLoader/DataLoaderInterface.php
+++ b/src/Docker/Runner/DataLoader/DataLoaderInterface.php
@@ -4,6 +4,7 @@ namespace Keboola\DockerBundle\Docker\Runner\DataLoader;
 
 use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Docker\OutputFilter\OutputFilterInterface;
+use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 use Keboola\StorageApi\Client;
 use Psr\Log\LoggerInterface;
 
@@ -13,6 +14,9 @@ interface DataLoaderInterface
 
     public function loadInputData();
 
+    /**
+     * @return LoadTableQueue|null
+     */
     public function storeOutput();
 
     public function storeDataArchive($fileName, array $tags);

--- a/src/Docker/Runner/DataLoader/NullDataLoader.php
+++ b/src/Docker/Runner/DataLoader/NullDataLoader.php
@@ -19,7 +19,6 @@ class NullDataLoader implements DataLoaderInterface
 
     public function storeOutput()
     {
-        return null;
     }
 
     public function storeDataArchive($fileName, array $tags)

--- a/src/Docker/Runner/DataLoader/NullDataLoader.php
+++ b/src/Docker/Runner/DataLoader/NullDataLoader.php
@@ -19,7 +19,7 @@ class NullDataLoader implements DataLoaderInterface
 
     public function storeOutput()
     {
-        return [];
+        return null;
     }
 
     public function storeDataArchive($fileName, array $tags)

--- a/src/Docker/Runner/Output.php
+++ b/src/Docker/Runner/Output.php
@@ -20,9 +20,9 @@ class Output
     private $configVersion;
 
     /**
-     * @var array
+     * @var Job
      */
-    private $storageJobIds;
+    private $storageJob;
 
     /**
      * @var StateFile
@@ -68,14 +68,14 @@ class Output
         return $this->configVersion;
     }
 
-    public function setStorageJobIds(array $jobIds)
+    public function setStorageJob(Job $job)
     {
-        $this->storageJobIds = $jobIds;
+        $this->storageJob = $job;
     }
 
-    public function getStorageJobIds()
+    public function getStorageJob()
     {
-        return $this->storageJobIds;
+        return $this->storageJob;
     }
 
     public function getStateFile()

--- a/src/Docker/Runner/Output.php
+++ b/src/Docker/Runner/Output.php
@@ -2,6 +2,8 @@
 
 namespace Keboola\DockerBundle\Docker\Runner;
 
+use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
+
 class Output
 {
     /**
@@ -20,9 +22,9 @@ class Output
     private $configVersion;
 
     /**
-     * @var Job
+     * @var ?LoadTableQueue
      */
-    private $storageJob;
+    private $tableQueue;
 
     /**
      * @var StateFile
@@ -68,14 +70,14 @@ class Output
         return $this->configVersion;
     }
 
-    public function setStorageJob(Job $job)
+    public function setTableQueue(LoadTableQueue $tableQueue)
     {
-        $this->storageJob = $job;
+        $this->tableQueue = $tableQueue;
     }
 
-    public function getStorageJob()
+    public function getTableQueue()
     {
-        return $this->storageJob;
+        return $this->tableQueue;
     }
 
     public function getStateFile()

--- a/src/Docker/Runner/Output.php
+++ b/src/Docker/Runner/Output.php
@@ -70,7 +70,10 @@ class Output
         return $this->configVersion;
     }
 
-    public function setTableQueue(LoadTableQueue $tableQueue)
+    /**
+     * @param LoadTableQueue|null $tableQueue
+     */
+    public function setTableQueue($tableQueue)
     {
         $this->tableQueue = $tableQueue;
     }


### PR DESCRIPTION
refactor: removed support for parallel-output-mapping-load feature
feat: deferred loads are now the only behavior
refactor: uploadTables now returns LoadTableQueue queue object instead of array of job ids
replaces https://github.com/keboola/docker-bundle/pull/386