### PR TITLE
fix: catch 404 in persistState

### DIFF
--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -4,8 +4,10 @@ namespace Keboola\DockerBundle\Tests\Runner;
 
 use Keboola\DockerBundle\Docker\OutputFilter\NullFilter;
 use Keboola\DockerBundle\Docker\Runner\StateFile;
+use Keboola\DockerBundle\Exception\UserException;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
 use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
 use Keboola\Temp\Temp;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -348,5 +350,36 @@ class StateFileTest extends TestCase
         );
         self::assertEquals([], $stateFile->loadStateFromFile());
         self::assertFalse(file_exists($this->dataDir . '/out/state.json'));
+    }
+
+    public function test404()
+    {
+        $sapiStub = self::getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $sapiStub->expects(self::once())
+            ->method('apiPut')
+            ->with(
+                self::equalTo('storage/components/docker-demo/configs/config-id/rows/row-id'),
+                self::equalTo(['state' => '{"state":"fooBar"}'])
+            )
+            ->willThrowException(new ClientException("Test", 404));
+
+        /** @var Client $sapiStub */
+        $stateFile = new StateFile(
+            $this->dataDir,
+            $sapiStub,
+            $this->encryptorFactory,
+            ['state' => 'fooBarBaz'],
+            'json',
+            'docker-demo',
+            'config-id',
+            new NullFilter(),
+            'row-id'
+        );
+        $stateFile->stashState(['state' => 'fooBar']);
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage("Failed to store state: Test");
+        $stateFile->persistState();
     }
 }

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -352,7 +352,7 @@ class StateFileTest extends TestCase
         self::assertFalse(file_exists($this->dataDir . '/out/state.json'));
     }
 
-    public function test404()
+    public function testParse404()
     {
         $sapiStub = self::getMockBuilder(Client::class)
             ->disableOriginalConstructor()
@@ -380,6 +380,37 @@ class StateFileTest extends TestCase
         $stateFile->stashState(['state' => 'fooBar']);
         $this->expectException(UserException::class);
         $this->expectExceptionMessage("Failed to store state: Test");
+        $stateFile->persistState();
+    }
+
+    public function testPassOtherExceptions()
+    {
+        $sapiStub = self::getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $sapiStub->expects(self::once())
+            ->method('apiPut')
+            ->with(
+                self::equalTo('storage/components/docker-demo/configs/config-id/rows/row-id'),
+                self::equalTo(['state' => '{"state":"fooBar"}'])
+            )
+            ->willThrowException(new ClientException("Test", 888));
+
+        /** @var Client $sapiStub */
+        $stateFile = new StateFile(
+            $this->dataDir,
+            $sapiStub,
+            $this->encryptorFactory,
+            ['state' => 'fooBarBaz'],
+            'json',
+            'docker-demo',
+            'config-id',
+            new NullFilter(),
+            'row-id'
+        );
+        $stateFile->stashState(['state' => 'fooBar']);
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage("Test");
         $stateFile->persistState();
     }
 }

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -139,6 +139,7 @@ class StateFile
                 if ($e->getCode() === 404) {
                     throw new UserException("Failed to store state: " . $e->getMessage(), $e);
                 }
+                throw $e;
             }
         }
     }

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -4,9 +4,11 @@ namespace Keboola\DockerBundle\Docker\Runner;
 
 use Keboola\DockerBundle\Docker\Configuration\State\Adapter;
 use Keboola\DockerBundle\Docker\OutputFilter\OutputFilterInterface;
+use Keboola\DockerBundle\Exception\UserException;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWrapper;
 use Keboola\StorageApi\Client;
+use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
@@ -119,18 +121,24 @@ class StateFile
             $configuration = new Configuration();
             $configuration->setComponentId($this->componentId);
             $configuration->setConfigurationId($this->configurationId);
-            if ($this->configurationRowId) {
-                $configurationRow = new ConfigurationRow($configuration);
-                $configurationRow->setRowId($this->configurationRowId);
-                $configurationRow->setState(
-                    $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class)
-                );
-                $components->updateConfigurationRow($configurationRow);
-            } else {
-                $configuration->setState(
-                    $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class)
-                );
-                $components->updateConfiguration($configuration);
+            try {
+                if ($this->configurationRowId) {
+                    $configurationRow = new ConfigurationRow($configuration);
+                    $configurationRow->setRowId($this->configurationRowId);
+                    $configurationRow->setState(
+                        $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class)
+                    );
+                    $components->updateConfigurationRow($configurationRow);
+                } else {
+                    $configuration->setState(
+                        $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class)
+                    );
+                    $components->updateConfiguration($configuration);
+                }
+            } catch (ClientException $e) {
+                if ($e->getCode() === 404) {
+                    throw new UserException("Failed to store state: " . $e->getMessage(), $e);
+                }
             }
         }
     }


### PR DESCRIPTION
FIXES #393 
FIXES #315 

Celej blok na uložení state do configu/row jsem obalil try-catch s detekcí 404, která se mění na UserException