### PR TITLE
feat: adaptive input mapping

### DIFF
--- a/Tests/Runner/DataLoaderTest.php
+++ b/Tests/Runner/DataLoaderTest.php
@@ -9,6 +9,7 @@ use Keboola\DockerBundle\Docker\OutputFilter\OutputFilter;
 use Keboola\DockerBundle\Docker\Runner\DataLoader\DataLoader;
 use Keboola\DockerBundle\Exception\UserException;
 use Keboola\DockerBundle\Tests\BaseDataLoaderTest;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
 use Keboola\StorageApi\Options\GetFileOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\Temp\Temp;
@@ -204,7 +205,7 @@ class DataLoaderTest extends BaseDataLoaderTest
             $this->getS3StagingComponent(),
             new OutputFilter()
         );
-        $dataLoader->loadInputData();
+        $dataLoader->loadInputData(new InputTableStateList([]));
 
         $manifest = json_decode(
             file_get_contents($this->workingDir->getDataDir() . '/in/tables/in.c-docker-demo-testConfig.test.manifest'),

--- a/Tests/Runner/RunnerConfigRowsTest.php
+++ b/Tests/Runner/RunnerConfigRowsTest.php
@@ -551,8 +551,8 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
 
         self::assertEquals([], $configuration['state']);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE]);
     }
 
     public function testExecutorStoreRowStateWithProcessor()
@@ -628,8 +628,8 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $configuration = $component->getConfiguration('docker-demo', 'runner-configuration');
 
         self::assertEquals([], $configuration['state']);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE]);
     }
 
     public function testOutput()
@@ -762,9 +762,9 @@ class RunnerConfigRowsTest extends BaseRunnerTest
             'runner-configuration',
             null,
             [
-                StateFile::STORAGE_NAMESPACE_PREFIX => [
-                    StateFile::INPUT_NAMESPACE_PREFIX => [
-                        StateFile::TABLES_NAMESPACE_PREFIX => [
+                StateFile::STORAGE_NAMESPACE => [
+                    StateFile::INPUT_NAMESPACE => [
+                        StateFile::TABLES_NAMESPACE => [
                             [
                                 'source' => 'in.c-runner-test.mytable',
                                 'lastImportDate' => $tableInfo['lastImportDate'],
@@ -795,7 +795,7 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         self::assertEquals([], $configuration['state']);
         self::assertEquals(
             ['source' => 'in.c-runner-test.mytable', 'lastImportDate' => $updatedTableInfo['lastImportDate']],
-            $configuration['rows'][0]['state'][StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX][StateFile::TABLES_NAMESPACE_PREFIX][0]
+            $configuration['rows'][0]['state'][StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE][0]
         );
     }
 }

--- a/Tests/Runner/RunnerConfigRowsTest.php
+++ b/Tests/Runner/RunnerConfigRowsTest.php
@@ -692,7 +692,6 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         self::assertCount(1, $outputs[1]->getImages());
     }
 
-
     public function testRunRowAdaptiveInputMapping()
     {
         $temp = new Temp();

--- a/Tests/Runner/RunnerConfigRowsTest.php
+++ b/Tests/Runner/RunnerConfigRowsTest.php
@@ -546,8 +546,8 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
 
         self::assertEquals([], $configuration['state']);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::NAMESPACE_PREFIX]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
     }
 
     public function testExecutorStoreRowStateWithProcessor()
@@ -623,8 +623,8 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $configuration = $component->getConfiguration('docker-demo', 'runner-configuration');
 
         self::assertEquals([], $configuration['state']);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::NAMESPACE_PREFIX]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
     }
 
     public function testOutput()

--- a/Tests/Runner/RunnerConfigRowsTest.php
+++ b/Tests/Runner/RunnerConfigRowsTest.php
@@ -551,8 +551,8 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
 
         self::assertEquals([], $configuration['state']);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::NAMESPACE_COMPONENT]);
     }
 
     public function testExecutorStoreRowStateWithProcessor()
@@ -628,8 +628,8 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $configuration = $component->getConfiguration('docker-demo', 'runner-configuration');
 
         self::assertEquals([], $configuration['state']);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][0]['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals(['baz' => 'bar'], $configuration['rows'][1]['state'][StateFile::NAMESPACE_COMPONENT]);
     }
 
     public function testOutput()
@@ -762,9 +762,9 @@ class RunnerConfigRowsTest extends BaseRunnerTest
             'runner-configuration',
             null,
             [
-                StateFile::STORAGE_NAMESPACE => [
-                    StateFile::INPUT_NAMESPACE => [
-                        StateFile::TABLES_NAMESPACE => [
+                StateFile::NAMESPACE_STORAGE => [
+                    StateFile::NAMESPACE_INPUT => [
+                        StateFile::NAMESPACE_TABLES => [
                             [
                                 'source' => 'in.c-runner-test.mytable',
                                 'lastImportDate' => $tableInfo['lastImportDate'],
@@ -795,7 +795,7 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         self::assertEquals([], $configuration['state']);
         self::assertEquals(
             ['source' => 'in.c-runner-test.mytable', 'lastImportDate' => $updatedTableInfo['lastImportDate']],
-            $configuration['rows'][0]['state'][StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE][0]
+            $configuration['rows'][0]['state'][StateFile::NAMESPACE_STORAGE][StateFile::NAMESPACE_INPUT][StateFile::NAMESPACE_TABLES][0]
         );
     }
 }

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -426,10 +426,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE => [],
-            StateFile::STORAGE_NAMESPACE => [
-                StateFile::INPUT_NAMESPACE => [
-                    StateFile::TABLES_NAMESPACE => []
+            StateFile::NAMESPACE_COMPONENT => [],
+            StateFile::NAMESPACE_STORAGE => [
+                StateFile::NAMESPACE_INPUT => [
+                    StateFile::NAMESPACE_TABLES => []
                 ]
             ]
 
@@ -440,7 +440,7 @@ class RunnerTest extends BaseRunnerTest
     public function testClearStateWithNamespace()
     {
         $this->clearConfigurations();
-        $state = [StateFile::COMPONENT_NAMESPACE => ['key' => 'value']];
+        $state = [StateFile::NAMESPACE_COMPONENT => ['key' => 'value']];
         $cmp = new Components($this->getClient());
         $cfg = new Configuration();
         $cfg->setComponentId('keboola.docker-demo-sync');
@@ -474,10 +474,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE => [],
-            StateFile::STORAGE_NAMESPACE => [
-                StateFile::INPUT_NAMESPACE => [
-                    StateFile::TABLES_NAMESPACE => []
+            StateFile::NAMESPACE_COMPONENT => [],
+            StateFile::NAMESPACE_STORAGE => [
+                StateFile::NAMESPACE_INPUT => [
+                    StateFile::NAMESPACE_TABLES => []
                 ]
             ]
 
@@ -589,10 +589,10 @@ class RunnerTest extends BaseRunnerTest
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE => ['baz' => 'fooBar'],
-            StateFile::STORAGE_NAMESPACE => [
-                StateFile::INPUT_NAMESPACE => [
-                    StateFile::TABLES_NAMESPACE => []
+            StateFile::NAMESPACE_COMPONENT => ['baz' => 'fooBar'],
+            StateFile::NAMESPACE_STORAGE => [
+                StateFile::NAMESPACE_INPUT => [
+                    StateFile::NAMESPACE_TABLES => []
                 ]
             ]
 
@@ -643,12 +643,12 @@ class RunnerTest extends BaseRunnerTest
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertCount(1, $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertArrayHasKey('#encrypted', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertStringStartsWith('KBC::ProjectSecure::', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['#encrypted']);
+        self::assertCount(1, $configuration['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertArrayHasKey('#encrypted', $configuration['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertStringStartsWith('KBC::ProjectSecure::', $configuration['state'][StateFile::NAMESPACE_COMPONENT]['#encrypted']);
         self::assertEquals(
             'secret',
-            $this->getEncryptorFactory()->getEncryptor()->decrypt($configuration['state'][StateFile::COMPONENT_NAMESPACE]['#encrypted'])
+            $this->getEncryptorFactory()->getEncryptor()->decrypt($configuration['state'][StateFile::NAMESPACE_COMPONENT]['#encrypted'])
         );
         $this->clearConfigurations();
     }
@@ -704,7 +704,7 @@ class RunnerTest extends BaseRunnerTest
 
     public function testExecutorReadNamespacedState()
     {
-        $state = [StateFile::COMPONENT_NAMESPACE => ['foo' => 'bar']];
+        $state = [StateFile::NAMESPACE_COMPONENT => ['foo' => 'bar']];
         $this->clearConfigurations();
         $component = new Components($this->getClient());
         $configuration = new Configuration();
@@ -808,10 +808,10 @@ class RunnerTest extends BaseRunnerTest
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE => ['baz' => 'fooBar'],
-            StateFile::STORAGE_NAMESPACE => [
-                StateFile::INPUT_NAMESPACE => [
-                    StateFile::TABLES_NAMESPACE => []
+            StateFile::NAMESPACE_COMPONENT => ['baz' => 'fooBar'],
+            StateFile::NAMESPACE_STORAGE => [
+                StateFile::NAMESPACE_INPUT => [
+                    StateFile::NAMESPACE_TABLES => []
                 ]
             ]
 
@@ -828,7 +828,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::NAMESPACE_COMPONENT => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
@@ -891,8 +891,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals('bar', $configuration['state'][StateFile::NAMESPACE_COMPONENT]['foo']);
         $rows = $component->listConfigurationRows($listOptions);
         uasort(
             $rows,
@@ -902,10 +902,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $row1 = $rows[0];
         $row2 = $rows[1];
-        self::assertArrayHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals('fooBar1', $row1['state'][StateFile::COMPONENT_NAMESPACE]['bazRow1']);
-        self::assertArrayHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals('fooBar2', $row2['state'][StateFile::COMPONENT_NAMESPACE]['bazRow2']);
+        self::assertArrayHasKey('bazRow1', $row1['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals('fooBar1', $row1['state'][StateFile::NAMESPACE_COMPONENT]['bazRow1']);
+        self::assertArrayHasKey('bazRow2', $row2['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals('fooBar2', $row2['state'][StateFile::NAMESPACE_COMPONENT]['bazRow2']);
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
@@ -923,7 +923,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::NAMESPACE_COMPONENT => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
@@ -977,8 +977,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals('bar', $configuration['state'][StateFile::NAMESPACE_COMPONENT]['foo']);
         $row = $component->listConfigurationRows($listOptions)[0];
 
         self::assertArrayNotHasKey('component', $row['state']);
@@ -996,13 +996,13 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::NAMESPACE_COMPONENT => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
         $configurationRow->setRowId('row-1');
         $configurationRow->setName('Row 1');
-        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE => ['fooRow1' => 'barRow1']]);
+        $configurationRow->setState([StateFile::NAMESPACE_COMPONENT => ['fooRow1' => 'barRow1']]);
         $configData1 = [
             'parameters' => [
                 'script' => [
@@ -1020,7 +1020,7 @@ class RunnerTest extends BaseRunnerTest
         $configurationRow = new ConfigurationRow($configuration);
         $configurationRow->setRowId('row-2');
         $configurationRow->setName('Row 2');
-        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE => ['fooRow2' => 'barRow2']]);
+        $configurationRow->setState([StateFile::NAMESPACE_COMPONENT => ['fooRow2' => 'barRow2']]);
         $configData2 = [
             'parameters' => [
                 'script' => [
@@ -1071,8 +1071,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertEquals('bar', $configuration['state'][StateFile::NAMESPACE_COMPONENT]['foo']);
         $rows = $component->listConfigurationRows($listOptions);
         uasort(
             $rows,
@@ -1082,8 +1082,8 @@ class RunnerTest extends BaseRunnerTest
         );
         $row1 = $rows[0];
         $row2 = $rows[1];
-        self::assertArrayNotHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE]);
-        self::assertArrayNotHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertArrayNotHasKey('bazRow1', $row1['state'][StateFile::NAMESPACE_COMPONENT]);
+        self::assertArrayNotHasKey('bazRow2', $row2['state'][StateFile::NAMESPACE_COMPONENT]);
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
@@ -1099,7 +1099,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ['foo' => 'bar']]);
+        $configuration->setState([StateFile::NAMESPACE_COMPONENT => ['foo' => 'bar']]);
         $configData = [
             'parameters' => [
                 'script' => [
@@ -1151,7 +1151,7 @@ class RunnerTest extends BaseRunnerTest
         }
 
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::COMPONENT_NAMESPACE => ['foo' => 'bar']], $configuration['state'], 'State must not be changed');
+        self::assertEquals([StateFile::NAMESPACE_COMPONENT => ['foo' => 'bar']], $configuration['state'], 'State must not be changed');
         $this->clearConfigurations();
     }
 
@@ -1255,7 +1255,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertNotContains('state', $output, "No state must've been passed to the processor");
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE], 'State must be changed');
+        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::NAMESPACE_COMPONENT], 'State must be changed');
     }
 
     public function testExecutorBeforeProcessorNoState()
@@ -1358,7 +1358,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertNotContains('state', $output, "No state must've been passed to the processor");
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE], 'State must be changed');
+        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::NAMESPACE_COMPONENT], 'State must be changed');
     }
 
     public function testExecutorNoStoreState()
@@ -2448,9 +2448,9 @@ class RunnerTest extends BaseRunnerTest
             'runner-configuration',
             null,
             [
-                StateFile::STORAGE_NAMESPACE => [
-                    StateFile::INPUT_NAMESPACE => [
-                        StateFile::TABLES_NAMESPACE => [
+                StateFile::NAMESPACE_STORAGE => [
+                    StateFile::NAMESPACE_INPUT => [
+                        StateFile::NAMESPACE_TABLES => [
                             [
                                 'source' => 'in.c-runner-test.mytable',
                                 'lastImportDate' => $tableInfo['lastImportDate'],
@@ -2478,7 +2478,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration = $component->getConfiguration($componentDefinition->getId(), 'runner-configuration');
         self::assertEquals(
             ['source' => 'in.c-runner-test.mytable', 'lastImportDate' => $updatedTableInfo['lastImportDate']],
-            $configuration['state'][StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE][0]
+            $configuration['state'][StateFile::NAMESPACE_STORAGE][StateFile::NAMESPACE_INPUT][StateFile::NAMESPACE_TABLES][0]
         );
     }
 

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -424,14 +424,14 @@ class RunnerTest extends BaseRunnerTest
             new NullUsageFile()
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::NAMESPACE_PREFIX => []], $cfg['state']);
+        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => []], $cfg['state']);
         $this->clearConfigurations();
     }
 
     public function testClearStateWithNamespace()
     {
         $this->clearConfigurations();
-        $state = [StateFile::NAMESPACE_PREFIX => ['key' => 'value']];
+        $state = [StateFile::COMPONENT_NAMESPACE_PREFIX => ['key' => 'value']];
         $cmp = new Components($this->getClient());
         $cfg = new Configuration();
         $cfg->setComponentId('keboola.docker-demo-sync');
@@ -464,7 +464,7 @@ class RunnerTest extends BaseRunnerTest
             new NullUsageFile()
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::NAMESPACE_PREFIX => []], $cfg['state']);
+        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => []], $cfg['state']);
         $this->clearConfigurations();
     }
 
@@ -571,7 +571,7 @@ class RunnerTest extends BaseRunnerTest
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::NAMESPACE_PREFIX => ['baz' => 'fooBar']], $configuration['state']);
+        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar']], $configuration['state']);
         $this->clearConfigurations();
     }
 
@@ -618,12 +618,12 @@ class RunnerTest extends BaseRunnerTest
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertCount(1, $configuration['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertArrayHasKey('#encrypted', $configuration['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertStringStartsWith('KBC::ProjectSecure::', $configuration['state'][StateFile::NAMESPACE_PREFIX]['#encrypted']);
+        self::assertCount(1, $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertArrayHasKey('#encrypted', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertStringStartsWith('KBC::ProjectSecure::', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['#encrypted']);
         self::assertEquals(
             'secret',
-            $this->getEncryptorFactory()->getEncryptor()->decrypt($configuration['state'][StateFile::NAMESPACE_PREFIX]['#encrypted'])
+            $this->getEncryptorFactory()->getEncryptor()->decrypt($configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['#encrypted'])
         );
         $this->clearConfigurations();
     }
@@ -679,7 +679,7 @@ class RunnerTest extends BaseRunnerTest
 
     public function testExecutorReadNamespacedState()
     {
-        $state = [StateFile::NAMESPACE_PREFIX => ['foo' => 'bar']];
+        $state = [StateFile::COMPONENT_NAMESPACE_PREFIX => ['foo' => 'bar']];
         $this->clearConfigurations();
         $component = new Components($this->getClient());
         $configuration = new Configuration();
@@ -782,7 +782,7 @@ class RunnerTest extends BaseRunnerTest
 
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::NAMESPACE_PREFIX => ['baz' => 'fooBar']], $configuration['state']);
+        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar']], $configuration['state']);
         $this->clearConfigurations();
     }
 
@@ -795,7 +795,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::NAMESPACE_PREFIX => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
@@ -858,8 +858,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals('bar', $configuration['state'][StateFile::NAMESPACE_PREFIX]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
         $rows = $component->listConfigurationRows($listOptions);
         uasort(
             $rows,
@@ -869,10 +869,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $row1 = $rows[0];
         $row2 = $rows[1];
-        self::assertArrayHasKey('bazRow1', $row1['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals('fooBar1', $row1['state'][StateFile::NAMESPACE_PREFIX]['bazRow1']);
-        self::assertArrayHasKey('bazRow2', $row2['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals('fooBar2', $row2['state'][StateFile::NAMESPACE_PREFIX]['bazRow2']);
+        self::assertArrayHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals('fooBar1', $row1['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['bazRow1']);
+        self::assertArrayHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals('fooBar2', $row2['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['bazRow2']);
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
@@ -890,7 +890,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::NAMESPACE_PREFIX => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
@@ -944,8 +944,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals('bar', $configuration['state'][StateFile::NAMESPACE_PREFIX]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
         $row = $component->listConfigurationRows($listOptions)[0];
 
         self::assertArrayNotHasKey('component', $row['state']);
@@ -963,13 +963,13 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::NAMESPACE_PREFIX => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
         $configurationRow->setRowId('row-1');
         $configurationRow->setName('Row 1');
-        $configurationRow->setState([StateFile::NAMESPACE_PREFIX => ['fooRow1' => 'barRow1']]);
+        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ['fooRow1' => 'barRow1']]);
         $configData1 = [
             'parameters' => [
                 'script' => [
@@ -987,7 +987,7 @@ class RunnerTest extends BaseRunnerTest
         $configurationRow = new ConfigurationRow($configuration);
         $configurationRow->setRowId('row-2');
         $configurationRow->setName('Row 2');
-        $configurationRow->setState([StateFile::NAMESPACE_PREFIX => ['fooRow2' => 'barRow2']]);
+        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ['fooRow2' => 'barRow2']]);
         $configData2 = [
             'parameters' => [
                 'script' => [
@@ -1038,8 +1038,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertEquals('bar', $configuration['state'][StateFile::NAMESPACE_PREFIX]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
         $rows = $component->listConfigurationRows($listOptions);
         uasort(
             $rows,
@@ -1049,8 +1049,8 @@ class RunnerTest extends BaseRunnerTest
         );
         $row1 = $rows[0];
         $row2 = $rows[1];
-        self::assertArrayNotHasKey('bazRow1', $row1['state'][StateFile::NAMESPACE_PREFIX]);
-        self::assertArrayNotHasKey('bazRow2', $row2['state'][StateFile::NAMESPACE_PREFIX]);
+        self::assertArrayNotHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertArrayNotHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
@@ -1066,7 +1066,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::NAMESPACE_PREFIX => ['foo' => 'bar']]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ['foo' => 'bar']]);
         $configData = [
             'parameters' => [
                 'script' => [
@@ -1118,7 +1118,7 @@ class RunnerTest extends BaseRunnerTest
         }
 
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::NAMESPACE_PREFIX => ['foo' => 'bar']], $configuration['state'], 'State must not be changed');
+        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => ['foo' => 'bar']], $configuration['state'], 'State must not be changed');
         $this->clearConfigurations();
     }
 
@@ -1222,7 +1222,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertNotContains('state', $output, "No state must've been passed to the processor");
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::NAMESPACE_PREFIX], 'State must be changed');
+        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX], 'State must be changed');
     }
 
     public function testExecutorBeforeProcessorNoState()
@@ -1325,7 +1325,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertNotContains('state', $output, "No state must've been passed to the processor");
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::NAMESPACE_PREFIX], 'State must be changed');
+        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX], 'State must be changed');
     }
 
     public function testExecutorNoStoreState()

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -2338,7 +2338,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertCount(1, $output);
         self::assertEquals("Script file /data/script.py\nScript finished", $output[0]->getProcessOutput());
     }
-    
+
     public function testRunAdaptiveInputMapping()
     {
         $this->createBuckets();

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -425,7 +425,15 @@ class RunnerTest extends BaseRunnerTest
             new NullUsageFile()
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => []], $cfg['state']);
+        self::assertEquals([
+            StateFile::COMPONENT_NAMESPACE_PREFIX => [],
+            StateFile::STORAGE_NAMESPACE_PREFIX => [
+                StateFile::INPUT_NAMESPACE_PREFIX => [
+                    StateFile::TABLES_NAMESPACE_PREFIX => []
+                ]
+            ]
+
+        ], $cfg['state']);
         $this->clearConfigurations();
     }
 
@@ -465,7 +473,15 @@ class RunnerTest extends BaseRunnerTest
             new NullUsageFile()
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => []], $cfg['state']);
+        self::assertEquals([
+            StateFile::COMPONENT_NAMESPACE_PREFIX => [],
+            StateFile::STORAGE_NAMESPACE_PREFIX => [
+                StateFile::INPUT_NAMESPACE_PREFIX => [
+                    StateFile::TABLES_NAMESPACE_PREFIX => []
+                ]
+            ]
+
+        ], $cfg['state']);
         $this->clearConfigurations();
     }
 
@@ -572,7 +588,15 @@ class RunnerTest extends BaseRunnerTest
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar']], $configuration['state']);
+        self::assertEquals([
+            StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar'],
+            StateFile::STORAGE_NAMESPACE_PREFIX => [
+                StateFile::INPUT_NAMESPACE_PREFIX => [
+                    StateFile::TABLES_NAMESPACE_PREFIX => []
+                ]
+            ]
+
+        ], $configuration['state']);
         $this->clearConfigurations();
     }
 
@@ -783,7 +807,15 @@ class RunnerTest extends BaseRunnerTest
 
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar']], $configuration['state']);
+        self::assertEquals([
+            StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar'],
+            StateFile::STORAGE_NAMESPACE_PREFIX => [
+                StateFile::INPUT_NAMESPACE_PREFIX => [
+                    StateFile::TABLES_NAMESPACE_PREFIX => []
+                ]
+            ]
+
+        ], $configuration['state']);
         $this->clearConfigurations();
     }
 

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -426,10 +426,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE_PREFIX => [],
-            StateFile::STORAGE_NAMESPACE_PREFIX => [
-                StateFile::INPUT_NAMESPACE_PREFIX => [
-                    StateFile::TABLES_NAMESPACE_PREFIX => []
+            StateFile::COMPONENT_NAMESPACE => [],
+            StateFile::STORAGE_NAMESPACE => [
+                StateFile::INPUT_NAMESPACE => [
+                    StateFile::TABLES_NAMESPACE => []
                 ]
             ]
 
@@ -440,7 +440,7 @@ class RunnerTest extends BaseRunnerTest
     public function testClearStateWithNamespace()
     {
         $this->clearConfigurations();
-        $state = [StateFile::COMPONENT_NAMESPACE_PREFIX => ['key' => 'value']];
+        $state = [StateFile::COMPONENT_NAMESPACE => ['key' => 'value']];
         $cmp = new Components($this->getClient());
         $cfg = new Configuration();
         $cfg->setComponentId('keboola.docker-demo-sync');
@@ -474,10 +474,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE_PREFIX => [],
-            StateFile::STORAGE_NAMESPACE_PREFIX => [
-                StateFile::INPUT_NAMESPACE_PREFIX => [
-                    StateFile::TABLES_NAMESPACE_PREFIX => []
+            StateFile::COMPONENT_NAMESPACE => [],
+            StateFile::STORAGE_NAMESPACE => [
+                StateFile::INPUT_NAMESPACE => [
+                    StateFile::TABLES_NAMESPACE => []
                 ]
             ]
 
@@ -589,10 +589,10 @@ class RunnerTest extends BaseRunnerTest
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar'],
-            StateFile::STORAGE_NAMESPACE_PREFIX => [
-                StateFile::INPUT_NAMESPACE_PREFIX => [
-                    StateFile::TABLES_NAMESPACE_PREFIX => []
+            StateFile::COMPONENT_NAMESPACE => ['baz' => 'fooBar'],
+            StateFile::STORAGE_NAMESPACE => [
+                StateFile::INPUT_NAMESPACE => [
+                    StateFile::TABLES_NAMESPACE => []
                 ]
             ]
 
@@ -643,12 +643,12 @@ class RunnerTest extends BaseRunnerTest
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertCount(1, $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertArrayHasKey('#encrypted', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertStringStartsWith('KBC::ProjectSecure::', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['#encrypted']);
+        self::assertCount(1, $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertArrayHasKey('#encrypted', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertStringStartsWith('KBC::ProjectSecure::', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['#encrypted']);
         self::assertEquals(
             'secret',
-            $this->getEncryptorFactory()->getEncryptor()->decrypt($configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['#encrypted'])
+            $this->getEncryptorFactory()->getEncryptor()->decrypt($configuration['state'][StateFile::COMPONENT_NAMESPACE]['#encrypted'])
         );
         $this->clearConfigurations();
     }
@@ -704,7 +704,7 @@ class RunnerTest extends BaseRunnerTest
 
     public function testExecutorReadNamespacedState()
     {
-        $state = [StateFile::COMPONENT_NAMESPACE_PREFIX => ['foo' => 'bar']];
+        $state = [StateFile::COMPONENT_NAMESPACE => ['foo' => 'bar']];
         $this->clearConfigurations();
         $component = new Components($this->getClient());
         $configuration = new Configuration();
@@ -808,10 +808,10 @@ class RunnerTest extends BaseRunnerTest
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
-            StateFile::COMPONENT_NAMESPACE_PREFIX => ['baz' => 'fooBar'],
-            StateFile::STORAGE_NAMESPACE_PREFIX => [
-                StateFile::INPUT_NAMESPACE_PREFIX => [
-                    StateFile::TABLES_NAMESPACE_PREFIX => []
+            StateFile::COMPONENT_NAMESPACE => ['baz' => 'fooBar'],
+            StateFile::STORAGE_NAMESPACE => [
+                StateFile::INPUT_NAMESPACE => [
+                    StateFile::TABLES_NAMESPACE => []
                 ]
             ]
 
@@ -828,7 +828,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
@@ -891,8 +891,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['foo']);
         $rows = $component->listConfigurationRows($listOptions);
         uasort(
             $rows,
@@ -902,10 +902,10 @@ class RunnerTest extends BaseRunnerTest
         );
         $row1 = $rows[0];
         $row2 = $rows[1];
-        self::assertArrayHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals('fooBar1', $row1['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['bazRow1']);
-        self::assertArrayHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals('fooBar2', $row2['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['bazRow2']);
+        self::assertArrayHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals('fooBar1', $row1['state'][StateFile::COMPONENT_NAMESPACE]['bazRow1']);
+        self::assertArrayHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals('fooBar2', $row2['state'][StateFile::COMPONENT_NAMESPACE]['bazRow2']);
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 1 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Running component keboola.docker-demo-sync (row 2 of 2)'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
@@ -923,7 +923,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
@@ -977,8 +977,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['foo']);
         $row = $component->listConfigurationRows($listOptions)[0];
 
         self::assertArrayNotHasKey('component', $row['state']);
@@ -996,13 +996,13 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ["foo" => "bar"]]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ["foo" => "bar"]]);
         $component->addConfiguration($configuration);
 
         $configurationRow = new ConfigurationRow($configuration);
         $configurationRow->setRowId('row-1');
         $configurationRow->setName('Row 1');
-        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ['fooRow1' => 'barRow1']]);
+        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE => ['fooRow1' => 'barRow1']]);
         $configData1 = [
             'parameters' => [
                 'script' => [
@@ -1020,7 +1020,7 @@ class RunnerTest extends BaseRunnerTest
         $configurationRow = new ConfigurationRow($configuration);
         $configurationRow->setRowId('row-2');
         $configurationRow->setName('Row 2');
-        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ['fooRow2' => 'barRow2']]);
+        $configurationRow->setState([StateFile::COMPONENT_NAMESPACE => ['fooRow2' => 'barRow2']]);
         $configData2 = [
             'parameters' => [
                 'script' => [
@@ -1071,8 +1071,8 @@ class RunnerTest extends BaseRunnerTest
         $listOptions->setComponentId('keboola.docker-demo-sync')->setConfigurationId('runner-configuration');
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         // configuration state should be unchanged
-        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
+        self::assertArrayHasKey('foo', $configuration['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertEquals('bar', $configuration['state'][StateFile::COMPONENT_NAMESPACE]['foo']);
         $rows = $component->listConfigurationRows($listOptions);
         uasort(
             $rows,
@@ -1082,8 +1082,8 @@ class RunnerTest extends BaseRunnerTest
         );
         $row1 = $rows[0];
         $row2 = $rows[1];
-        self::assertArrayNotHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
-        self::assertArrayNotHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE_PREFIX]);
+        self::assertArrayNotHasKey('bazRow1', $row1['state'][StateFile::COMPONENT_NAMESPACE]);
+        self::assertArrayNotHasKey('bazRow2', $row2['state'][StateFile::COMPONENT_NAMESPACE]);
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-1'));
         self::assertTrue($this->client->tableExists('out.c-runner-test.my-table-2'));
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains('Waiting for Storage jobs'));
@@ -1099,7 +1099,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setComponentId('keboola.docker-demo-sync');
         $configuration->setName('Test configuration');
         $configuration->setConfigurationId('runner-configuration');
-        $configuration->setState([StateFile::COMPONENT_NAMESPACE_PREFIX => ['foo' => 'bar']]);
+        $configuration->setState([StateFile::COMPONENT_NAMESPACE => ['foo' => 'bar']]);
         $configData = [
             'parameters' => [
                 'script' => [
@@ -1151,7 +1151,7 @@ class RunnerTest extends BaseRunnerTest
         }
 
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals([StateFile::COMPONENT_NAMESPACE_PREFIX => ['foo' => 'bar']], $configuration['state'], 'State must not be changed');
+        self::assertEquals([StateFile::COMPONENT_NAMESPACE => ['foo' => 'bar']], $configuration['state'], 'State must not be changed');
         $this->clearConfigurations();
     }
 
@@ -1255,7 +1255,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertNotContains('state', $output, "No state must've been passed to the processor");
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX], 'State must be changed');
+        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE], 'State must be changed');
     }
 
     public function testExecutorBeforeProcessorNoState()
@@ -1358,7 +1358,7 @@ class RunnerTest extends BaseRunnerTest
         self::assertNotContains('state', $output, "No state must've been passed to the processor");
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
-        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE_PREFIX], 'State must be changed');
+        self::assertEquals(['bar' => 'Kochba'], $configuration['state'][StateFile::COMPONENT_NAMESPACE], 'State must be changed');
     }
 
     public function testExecutorNoStoreState()
@@ -2448,9 +2448,9 @@ class RunnerTest extends BaseRunnerTest
             'runner-configuration',
             null,
             [
-                StateFile::STORAGE_NAMESPACE_PREFIX => [
-                    StateFile::INPUT_NAMESPACE_PREFIX => [
-                        StateFile::TABLES_NAMESPACE_PREFIX => [
+                StateFile::STORAGE_NAMESPACE => [
+                    StateFile::INPUT_NAMESPACE => [
+                        StateFile::TABLES_NAMESPACE => [
                             [
                                 'source' => 'in.c-runner-test.mytable',
                                 'lastImportDate' => $tableInfo['lastImportDate'],
@@ -2478,7 +2478,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration = $component->getConfiguration($componentDefinition->getId(), 'runner-configuration');
         self::assertEquals(
             ['source' => 'in.c-runner-test.mytable', 'lastImportDate' => $updatedTableInfo['lastImportDate']],
-            $configuration['state'][StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX][StateFile::TABLES_NAMESPACE_PREFIX][0]
+            $configuration['state'][StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE][0]
         );
     }
 

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -72,7 +72,7 @@ class StateFileTest extends TestCase
             $this->encryptorFactory,
             [
                 'otherNamespace' => 'value',
-                StateFile::COMPONENT_NAMESPACE_PREFIX => ['lastUpdate' => 'today']
+                StateFile::COMPONENT_NAMESPACE => ['lastUpdate' => 'today']
             ],
             'json',
             'docker-demo',
@@ -145,12 +145,12 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => [
+                        StateFile::COMPONENT_NAMESPACE => [
                             'key' => 'fooBar'
                         ],
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => []
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => []
                             ]
                         ],
 
@@ -187,11 +187,11 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertArrayHasKey('foo', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['key']);
-                    self::assertEquals('bar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
+                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertArrayHasKey('foo', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
+                    self::assertEquals('bar', $data[StateFile::COMPONENT_NAMESPACE]['foo']);
                     return true;
                 })
             );
@@ -223,11 +223,11 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertArrayHasKey('foo', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['key']);
-                    self::assertEquals('bar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['foo']);
+                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertArrayHasKey('foo', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
+                    self::assertEquals('bar', $data[StateFile::COMPONENT_NAMESPACE]['foo']);
                     return true;
                 })
             );
@@ -259,10 +259,10 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['key']);
-                    self::assertArrayHasKey('#foo', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertStringStartsWith('KBC::ProjectSecure::', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['#foo']);
+                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
+                    self::assertArrayHasKey('#foo', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertStringStartsWith('KBC::ProjectSecure::', $data[StateFile::COMPONENT_NAMESPACE]['#foo']);
                     return true;
                 })
             );
@@ -316,9 +316,9 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['key']);
+                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
                     return true;
                 })
             );
@@ -349,10 +349,10 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => [],
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => []
+                        StateFile::COMPONENT_NAMESPACE => [],
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => []
                             ]
                         ],
 
@@ -386,10 +386,10 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => new \stdClass(),
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => []
+                        StateFile::COMPONENT_NAMESPACE => new \stdClass(),
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => []
                             ]
                         ],
 
@@ -423,12 +423,12 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => [
+                        StateFile::COMPONENT_NAMESPACE => [
                             'key' => 'fooBar'
                         ],
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => []
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => []
                             ]
                         ],
 
@@ -441,7 +441,7 @@ class StateFileTest extends TestCase
             $this->dataDir,
             $sapiStub,
             $this->encryptorFactory,
-            [StateFile::COMPONENT_NAMESPACE_PREFIX => ['key' => 'fooBar']],
+            [StateFile::COMPONENT_NAMESPACE => ['key' => 'fooBar']],
             'json',
             'docker-demo',
             'config-id',
@@ -462,12 +462,12 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => [
+                        StateFile::COMPONENT_NAMESPACE => [
                             'key' => 'fooBar'
                         ],
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => []
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => []
                             ]
                         ],
 
@@ -559,9 +559,9 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['key']);
+                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
                     return true;
                 })
             )
@@ -597,9 +597,9 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE_PREFIX]['key']);
+                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
+                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
                     return true;
                 })
             )
@@ -637,10 +637,10 @@ class StateFileTest extends TestCase
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
                     self::assertEquals([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => [],
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => [
+                        StateFile::COMPONENT_NAMESPACE => [],
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => [
                                     [
                                         'source' => 'in.c-main.test',
                                         'lastImportDate' => 'today'
@@ -687,10 +687,10 @@ class StateFileTest extends TestCase
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
                     self::assertEquals([
-                        StateFile::COMPONENT_NAMESPACE_PREFIX => [],
-                        StateFile::STORAGE_NAMESPACE_PREFIX => [
-                            StateFile::INPUT_NAMESPACE_PREFIX => [
-                                StateFile::TABLES_NAMESPACE_PREFIX => [
+                        StateFile::COMPONENT_NAMESPACE => [],
+                        StateFile::STORAGE_NAMESPACE => [
+                            StateFile::INPUT_NAMESPACE => [
+                                StateFile::TABLES_NAMESPACE => [
                                     [
                                         'source' => 'in.c-main.test',
                                         'lastImportDate' => 'today'

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -72,7 +72,7 @@ class StateFileTest extends TestCase
             $this->encryptorFactory,
             [
                 'otherNamespace' => 'value',
-                StateFile::COMPONENT_NAMESPACE => ['lastUpdate' => 'today']
+                StateFile::NAMESPACE_COMPONENT => ['lastUpdate' => 'today']
             ],
             'json',
             'docker-demo',
@@ -145,12 +145,12 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE => [
+                        StateFile::NAMESPACE_COMPONENT => [
                             'key' => 'fooBar'
                         ],
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => []
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => []
                             ]
                         ],
 
@@ -187,11 +187,11 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertArrayHasKey('foo', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
-                    self::assertEquals('bar', $data[StateFile::COMPONENT_NAMESPACE]['foo']);
+                    self::assertArrayHasKey(StateFile::NAMESPACE_COMPONENT, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertArrayHasKey('foo', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertEquals('fooBar', $data[StateFile::NAMESPACE_COMPONENT]['key']);
+                    self::assertEquals('bar', $data[StateFile::NAMESPACE_COMPONENT]['foo']);
                     return true;
                 })
             );
@@ -223,11 +223,11 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertArrayHasKey('foo', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
-                    self::assertEquals('bar', $data[StateFile::COMPONENT_NAMESPACE]['foo']);
+                    self::assertArrayHasKey(StateFile::NAMESPACE_COMPONENT, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertArrayHasKey('foo', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertEquals('fooBar', $data[StateFile::NAMESPACE_COMPONENT]['key']);
+                    self::assertEquals('bar', $data[StateFile::NAMESPACE_COMPONENT]['foo']);
                     return true;
                 })
             );
@@ -259,10 +259,10 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
-                    self::assertArrayHasKey('#foo', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertStringStartsWith('KBC::ProjectSecure::', $data[StateFile::COMPONENT_NAMESPACE]['#foo']);
+                    self::assertArrayHasKey('key', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertEquals('fooBar', $data[StateFile::NAMESPACE_COMPONENT]['key']);
+                    self::assertArrayHasKey('#foo', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertStringStartsWith('KBC::ProjectSecure::', $data[StateFile::NAMESPACE_COMPONENT]['#foo']);
                     return true;
                 })
             );
@@ -316,9 +316,9 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
+                    self::assertArrayHasKey(StateFile::NAMESPACE_COMPONENT, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertEquals('fooBar', $data[StateFile::NAMESPACE_COMPONENT]['key']);
                     return true;
                 })
             );
@@ -349,10 +349,10 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE => [],
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => []
+                        StateFile::NAMESPACE_COMPONENT => [],
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => []
                             ]
                         ],
 
@@ -386,10 +386,10 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE => new \stdClass(),
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => []
+                        StateFile::NAMESPACE_COMPONENT => new \stdClass(),
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => []
                             ]
                         ],
 
@@ -423,12 +423,12 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE => [
+                        StateFile::NAMESPACE_COMPONENT => [
                             'key' => 'fooBar'
                         ],
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => []
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => []
                             ]
                         ],
 
@@ -441,7 +441,7 @@ class StateFileTest extends TestCase
             $this->dataDir,
             $sapiStub,
             $this->encryptorFactory,
-            [StateFile::COMPONENT_NAMESPACE => ['key' => 'fooBar']],
+            [StateFile::NAMESPACE_COMPONENT => ['key' => 'fooBar']],
             'json',
             'docker-demo',
             'config-id',
@@ -462,12 +462,12 @@ class StateFileTest extends TestCase
                 self::equalTo('storage/components/docker-demo/configs/config-id'),
                 self::equalTo(
                     ['state' => json_encode([
-                        StateFile::COMPONENT_NAMESPACE => [
+                        StateFile::NAMESPACE_COMPONENT => [
                             'key' => 'fooBar'
                         ],
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => []
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => []
                             ]
                         ],
 
@@ -559,9 +559,9 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
+                    self::assertArrayHasKey(StateFile::NAMESPACE_COMPONENT, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertEquals('fooBar', $data[StateFile::NAMESPACE_COMPONENT]['key']);
                     return true;
                 })
             )
@@ -597,9 +597,9 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE, $data);
-                    self::assertArrayHasKey('key', $data[StateFile::COMPONENT_NAMESPACE]);
-                    self::assertEquals('fooBar', $data[StateFile::COMPONENT_NAMESPACE]['key']);
+                    self::assertArrayHasKey(StateFile::NAMESPACE_COMPONENT, $data);
+                    self::assertArrayHasKey('key', $data[StateFile::NAMESPACE_COMPONENT]);
+                    self::assertEquals('fooBar', $data[StateFile::NAMESPACE_COMPONENT]['key']);
                     return true;
                 })
             )
@@ -637,10 +637,10 @@ class StateFileTest extends TestCase
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
                     self::assertEquals([
-                        StateFile::COMPONENT_NAMESPACE => [],
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => [
+                        StateFile::NAMESPACE_COMPONENT => [],
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => [
                                     [
                                         'source' => 'in.c-main.test',
                                         'lastImportDate' => 'today'
@@ -687,10 +687,10 @@ class StateFileTest extends TestCase
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
                     self::assertEquals([
-                        StateFile::COMPONENT_NAMESPACE => [],
-                        StateFile::STORAGE_NAMESPACE => [
-                            StateFile::INPUT_NAMESPACE => [
-                                StateFile::TABLES_NAMESPACE => [
+                        StateFile::NAMESPACE_COMPONENT => [],
+                        StateFile::NAMESPACE_STORAGE => [
+                            StateFile::NAMESPACE_INPUT => [
+                                StateFile::NAMESPACE_TABLES => [
                                     [
                                         'source' => 'in.c-main.test',
                                         'lastImportDate' => 'today'

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -154,8 +154,8 @@ class StateFileTest extends TestCase
                             ]
                         ],
 
-                    ])
-                ])
+                    ])]
+                )
             );
 
 
@@ -356,8 +356,8 @@ class StateFileTest extends TestCase
                             ]
                         ],
 
-                    ])
-                ])
+                    ])]
+                )
             );
 
         /** @var Client $sapiStub */
@@ -393,8 +393,8 @@ class StateFileTest extends TestCase
                             ]
                         ],
 
-                    ])
-                ])
+                    ])]
+                )
             );
 
         /** @var Client $sapiStub */
@@ -432,8 +432,8 @@ class StateFileTest extends TestCase
                             ]
                         ],
 
-                    ])
-                ])
+                    ])]
+                )
             );
 
         /** @var Client $sapiStub */
@@ -471,8 +471,8 @@ class StateFileTest extends TestCase
                             ]
                         ],
 
-                    ])
-                ])
+                    ])]
+                )
             );
 
         /** @var Client $sapiStub */

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -636,16 +636,19 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey(StateFile::STORAGE_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey(StateFile::INPUT_NAMESPACE_PREFIX, $data[StateFile::STORAGE_NAMESPACE_PREFIX]);
-                    self::assertArrayHasKey(StateFile::TABLES_NAMESPACE_PREFIX, $data[StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX]);
-                    $storedState = $data[StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX][StateFile::TABLES_NAMESPACE_PREFIX];
-                    self::assertCount(1, $storedState);
                     self::assertEquals([
-                        'source' => 'in.c-main.test',
-                        'lastImportDate' => 'today'
-                    ], $storedState[0]);
+                        StateFile::COMPONENT_NAMESPACE_PREFIX => [],
+                        StateFile::STORAGE_NAMESPACE_PREFIX => [
+                            StateFile::INPUT_NAMESPACE_PREFIX => [
+                                StateFile::TABLES_NAMESPACE_PREFIX => [
+                                    [
+                                        'source' => 'in.c-main.test',
+                                        'lastImportDate' => 'today'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ], $data);
                     return true;
                 })
             );
@@ -683,16 +686,19 @@ class StateFileTest extends TestCase
                 $this->callback(function ($argument) {
                     self::assertArrayHasKey('state', $argument);
                     $data = \GuzzleHttp\json_decode($argument['state'], true);
-                    self::assertArrayHasKey(StateFile::COMPONENT_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey(StateFile::STORAGE_NAMESPACE_PREFIX, $data);
-                    self::assertArrayHasKey(StateFile::INPUT_NAMESPACE_PREFIX, $data[StateFile::STORAGE_NAMESPACE_PREFIX]);
-                    self::assertArrayHasKey(StateFile::TABLES_NAMESPACE_PREFIX, $data[StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX]);
-                    $storedState = $data[StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX][StateFile::TABLES_NAMESPACE_PREFIX];
-                    self::assertCount(1, $storedState);
                     self::assertEquals([
-                        'source' => 'in.c-main.test',
-                        'lastImportDate' => 'today'
-                    ], $storedState[0]);
+                        StateFile::COMPONENT_NAMESPACE_PREFIX => [],
+                        StateFile::STORAGE_NAMESPACE_PREFIX => [
+                            StateFile::INPUT_NAMESPACE_PREFIX => [
+                                StateFile::TABLES_NAMESPACE_PREFIX => [
+                                    [
+                                        'source' => 'in.c-main.test',
+                                        'lastImportDate' => 'today'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ], $data);
                     return true;
                 })
             );

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "keboola/php-utils": "^2.0",
         "keboola/oauth-v2-php-client": "^2.2",
         "keboola/gelf-server": "^2.0",
-        "keboola/input-mapping": "dev-najlos-input-table-state as 7.1",
+        "keboola/input-mapping": "^8.0",
         "keboola/output-mapping": "^8.0",
         "symfony/validator": "^2.8|^4.1",
         "vkartaviy/retry": "^0.2",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "keboola/php-utils": "^2.0",
         "keboola/oauth-v2-php-client": "^2.2",
         "keboola/gelf-server": "^2.0",
-        "keboola/input-mapping": "^7.0",
+        "keboola/input-mapping": "dev-najlos-input-table-state as 7.1",
         "keboola/output-mapping": "^8.0",
         "symfony/validator": "^2.8|^4.1",
         "vkartaviy/retry": "^0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddcc298aad59019ededf25581aac9ea7",
+    "content-hash": "219da094b7cb3adfefe6eb9436f61eb9",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1809,17 +1809,17 @@
         },
         {
             "name": "keboola/input-mapping",
-            "version": "7.0.0",
+            "version": "dev-najlos-input-table-state",
             "target-dir": "Keboola/InputMapping",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "856d4c768f93d1c76bd4b0cdcfb766991c517ed0"
+                "reference": "c882d6ae03ba9f9a6eae55f88b88c863c7f79bb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/856d4c768f93d1c76bd4b0cdcfb766991c517ed0",
-                "reference": "856d4c768f93d1c76bd4b0cdcfb766991c517ed0",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/c882d6ae03ba9f9a6eae55f88b88c863c7f79bb8",
+                "reference": "c882d6ae03ba9f9a6eae55f88b88c863c7f79bb8",
                 "shasum": ""
             },
             "require": {
@@ -1853,7 +1853,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI input mapping and exporting to files",
-            "time": "2019-03-12T08:20:55+00:00"
+            "time": "2019-03-25T13:53:33+00:00"
         },
         {
             "name": "keboola/oauth-v2-php-client",
@@ -6453,9 +6453,18 @@
             "time": "2018-12-25T11:19:39+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "7.1",
+            "alias_normalized": "7.1.0.0",
+            "version": "dev-najlos-input-table-state",
+            "package": "keboola/input-mapping"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "keboola/input-mapping": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "219da094b7cb3adfefe6eb9436f61eb9",
+    "content-hash": "9fc18a2ab5fd15e82d99e292e2df1ff3",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1809,17 +1809,17 @@
         },
         {
             "name": "keboola/input-mapping",
-            "version": "dev-najlos-input-table-state",
+            "version": "8.0.0",
             "target-dir": "Keboola/InputMapping",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "c882d6ae03ba9f9a6eae55f88b88c863c7f79bb8"
+                "reference": "54af99d3952999f56377d912cacbb9c0f9e6325c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/c882d6ae03ba9f9a6eae55f88b88c863c7f79bb8",
-                "reference": "c882d6ae03ba9f9a6eae55f88b88c863c7f79bb8",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/54af99d3952999f56377d912cacbb9c0f9e6325c",
+                "reference": "54af99d3952999f56377d912cacbb9c0f9e6325c",
                 "shasum": ""
             },
             "require": {
@@ -1853,7 +1853,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI input mapping and exporting to files",
-            "time": "2019-03-25T13:53:33+00:00"
+            "time": "2019-03-27T16:55:37+00:00"
         },
         {
             "name": "keboola/oauth-v2-php-client",
@@ -1948,22 +1948,22 @@
         },
         {
             "name": "keboola/output-mapping",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "target-dir": "Keboola/OutputMapping",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/output-mapping.git",
-                "reference": "fc8358eda4c320ff54cc5cddbc64002a72060590"
+                "reference": "ad67d05838ce783dfc46d1d5e6cacb934abb65cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/fc8358eda4c320ff54cc5cddbc64002a72060590",
-                "reference": "fc8358eda4c320ff54cc5cddbc64002a72060590",
+                "url": "https://api.github.com/repos/keboola/output-mapping/zipball/ad67d05838ce783dfc46d1d5e6cacb934abb65cc",
+                "reference": "ad67d05838ce783dfc46d1d5e6cacb934abb65cc",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^6.2",
-                "keboola/input-mapping": "^7.0",
+                "keboola/input-mapping": "^8.0",
                 "keboola/sanitizer": "^0.1",
                 "monolog/monolog": "^1.22",
                 "symfony/config": "^2.8|^4.1",
@@ -1993,7 +1993,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
-            "time": "2019-03-12T13:21:14+00:00"
+            "time": "2019-03-28T07:44:29+00:00"
         },
         {
             "name": "keboola/php-encryption",
@@ -6453,18 +6453,9 @@
             "time": "2018-12-25T11:19:39+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "7.1",
-            "alias_normalized": "7.1.0.0",
-            "version": "dev-najlos-input-table-state",
-            "package": "keboola/input-mapping"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "keboola/input-mapping": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -277,9 +277,9 @@ class Runner
             $configData
         );
 
-        if (isset($jobDefinition->getState()[StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE])) {
+        if (isset($jobDefinition->getState()[StateFile::NAMESPACE_STORAGE][StateFile::NAMESPACE_INPUT][StateFile::NAMESPACE_TABLES])) {
             $inputTableStateList = new InputTableStateList(
-                $jobDefinition->getState()[StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE]
+                $jobDefinition->getState()[StateFile::NAMESPACE_STORAGE][StateFile::NAMESPACE_INPUT][StateFile::NAMESPACE_TABLES]
             );
         } else {
             $inputTableStateList = new InputTableStateList([]);

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -339,7 +339,7 @@ class Runner
         $this->waitForStorageJobs($outputs);
         /** @var Output $output */
         foreach ($outputs as $output) {
-            $output->getStateFile()->persistState();
+            $output->getStateFile()->persistState($output->getInputTableStateList());
         }
         return $outputs;
     }
@@ -385,9 +385,10 @@ class Runner
     {
         // initialize
         $workingDirectory->createWorkingDir();
-        $dataLoader->loadInputData();
+        $inputTablesState = $dataLoader->loadInputData();
 
         $output = $this->runImages($jobId, $configId, $rowId, $component, $usageFile, $workingDirectory, $imageCreator, $configFile, $stateFile, $outputFilter, $dataLoader, $configVersion, $mode);
+        $output->setInputTableStateList($inputTablesState);
 
         if ($mode === self::MODE_DEBUG) {
             $dataLoader->storeDataArchive('stage_output', [self::MODE_DEBUG, $component->getId(), 'RowId:' . $rowId, 'JobId:' . $jobId]);

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -277,9 +277,9 @@ class Runner
             $configData
         );
 
-        if (isset($jobDefinition->getState()[StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX][StateFile::TABLES_NAMESPACE_PREFIX])) {
+        if (isset($jobDefinition->getState()[StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE])) {
             $inputTableStateList = new InputTableStateList(
-                $jobDefinition->getState()[StateFile::STORAGE_NAMESPACE_PREFIX][StateFile::INPUT_NAMESPACE_PREFIX][StateFile::TABLES_NAMESPACE_PREFIX]
+                $jobDefinition->getState()[StateFile::STORAGE_NAMESPACE][StateFile::INPUT_NAMESPACE][StateFile::TABLES_NAMESPACE]
             );
         } else {
             $inputTableStateList = new InputTableStateList([]);

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -348,7 +348,9 @@ class Runner
         $this->waitForStorageJobs($outputs);
         /** @var Output $output */
         foreach ($outputs as $output) {
-            $output->getStateFile()->persistState($output->getInputTableStateList());
+            if (($mode !== self::MODE_DEBUG) && $this->shouldStoreState($jobDefinition->getComponentId(), $jobDefinition->getConfigId())) {
+                $output->getStateFile()->persistState($output->getInputTableStateList());
+            }
         }
         return $outputs;
     }
@@ -515,9 +517,7 @@ class Runner
                 $workingDirectory->moveOutputToInput();
             }
         }
-        if (($mode !== self::MODE_DEBUG) && $this->shouldStoreState($component->getId(), $configId)) {
-            $stateFile->stashState($newState);
-        }
+        $stateFile->stashState($newState);
         return new Output($imageDigests, $outputMessage, $configVersion, $stateFile);
     }
 }

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -9,6 +9,7 @@ use Keboola\DockerBundle\Exception\UserException;
 use Keboola\InputMapping\Exception\InvalidInputException;
 use Keboola\InputMapping\Reader\Options\InputTablesOptions;
 use Keboola\InputMapping\Reader\Reader;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Writer\Writer;
 use Keboola\StorageApi\Client;
@@ -106,11 +107,12 @@ class DataLoader implements DataLoaderInterface
     {
         $reader = new Reader($this->storageClient, $this->logger);
         $reader->setFormat($this->component->getConfigurationFormat());
+        $inputTablesState = new InputTableStateList([]);
 
         try {
             if (isset($this->storageConfig['input']['tables']) && count($this->storageConfig['input']['tables'])) {
                 $this->logger->debug('Downloading source tables.');
-                $reader->downloadTables(
+                $inputTablesState = $reader->downloadTables(
                     new InputTablesOptions($this->storageConfig['input']['tables']),
                     $this->dataDirectory . DIRECTORY_SEPARATOR . 'in' . DIRECTORY_SEPARATOR . 'tables',
                     $this->getStagingStorageInput()
@@ -130,6 +132,7 @@ class DataLoader implements DataLoaderInterface
         } catch (InvalidInputException $e) {
             throw new UserException($e->getMessage(), $e);
         }
+        return $inputTablesState;
     }
 
     public function storeOutput()

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -111,6 +111,8 @@ class DataLoader implements DataLoaderInterface
         $reader = new Reader($this->storageClient, $this->logger);
         $reader->setFormat($this->component->getConfigurationFormat());
 
+        $resultInputTablesStateList = new InputTableStateList([]);
+        
         try {
             if (isset($this->storageConfig['input']['tables']) && count($this->storageConfig['input']['tables'])) {
                 $this->logger->debug('Downloading source tables.');

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -7,7 +7,7 @@ use Keboola\DockerBundle\Docker\OutputFilter\OutputFilterInterface;
 use Keboola\DockerBundle\Exception\ApplicationException;
 use Keboola\DockerBundle\Exception\UserException;
 use Keboola\InputMapping\Exception\InvalidInputException;
-use Keboola\InputMapping\Reader\Options\InputTablesOptions;
+use Keboola\InputMapping\Reader\Options\InputTableOptionsList;
 use Keboola\InputMapping\Reader\Reader;
 use Keboola\InputMapping\Reader\State\InputTableStateList;
 use Keboola\OutputMapping\Exception\InvalidOutputException;
@@ -113,7 +113,7 @@ class DataLoader implements DataLoaderInterface
             if (isset($this->storageConfig['input']['tables']) && count($this->storageConfig['input']['tables'])) {
                 $this->logger->debug('Downloading source tables.');
                 $inputTablesState = $reader->downloadTables(
-                    new InputTablesOptions($this->storageConfig['input']['tables']),
+                    new InputTableOptionsList($this->storageConfig['input']['tables']),
                     $this->dataDirectory . DIRECTORY_SEPARATOR . 'in' . DIRECTORY_SEPARATOR . 'tables',
                     $this->getStagingStorageInput()
                 );

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -102,18 +102,21 @@ class DataLoader implements DataLoaderInterface
 
     /**
      * Download source files
+     * @param InputTableStateList $inputTableStateList
+     * @return InputTableStateList
+     * @throws \Keboola\StorageApi\Exception
      */
-    public function loadInputData()
+    public function loadInputData(InputTableStateList $inputTableStateList)
     {
         $reader = new Reader($this->storageClient, $this->logger);
         $reader->setFormat($this->component->getConfigurationFormat());
-        $inputTablesState = new InputTableStateList([]);
 
         try {
             if (isset($this->storageConfig['input']['tables']) && count($this->storageConfig['input']['tables'])) {
                 $this->logger->debug('Downloading source tables.');
-                $inputTablesState = $reader->downloadTables(
+                $resultInputTablesStateList = $reader->downloadTables(
                     new InputTableOptionsList($this->storageConfig['input']['tables']),
+                    $inputTableStateList,
                     $this->dataDirectory . DIRECTORY_SEPARATOR . 'in' . DIRECTORY_SEPARATOR . 'tables',
                     $this->getStagingStorageInput()
                 );
@@ -132,7 +135,7 @@ class DataLoader implements DataLoaderInterface
         } catch (InvalidInputException $e) {
             throw new UserException($e->getMessage(), $e);
         }
-        return $inputTablesState;
+        return $resultInputTablesStateList;
     }
 
     public function storeOutput()

--- a/src/Docker/Runner/DataLoader/DataLoaderInterface.php
+++ b/src/Docker/Runner/DataLoader/DataLoaderInterface.php
@@ -16,7 +16,7 @@ interface DataLoaderInterface
     /**
      * @return InputTableStateList
      */
-    public function loadInputData();
+    public function loadInputData(InputTableStateList $inputTableStateList);
 
     /**
      * @return LoadTableQueue|null

--- a/src/Docker/Runner/DataLoader/DataLoaderInterface.php
+++ b/src/Docker/Runner/DataLoader/DataLoaderInterface.php
@@ -4,6 +4,7 @@ namespace Keboola\DockerBundle\Docker\Runner\DataLoader;
 
 use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Docker\OutputFilter\OutputFilterInterface;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
 use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 use Keboola\StorageApi\Client;
 use Psr\Log\LoggerInterface;
@@ -12,6 +13,9 @@ interface DataLoaderInterface
 {
     public function __construct(Client $storageClient, LoggerInterface $logger, $dataDirectory, array $storageConfig, Component $component, OutputFilterInterface $outputFilter, $configId = null, $configRowId = null);
 
+    /**
+     * @return InputTableStateList
+     */
     public function loadInputData();
 
     /**

--- a/src/Docker/Runner/DataLoader/NullDataLoader.php
+++ b/src/Docker/Runner/DataLoader/NullDataLoader.php
@@ -13,7 +13,7 @@ class NullDataLoader implements DataLoaderInterface
     {
     }
 
-    public function loadInputData()
+    public function loadInputData(InputTableStateList $inputTableStateList)
     {
     }
 

--- a/src/Docker/Runner/DataLoader/NullDataLoader.php
+++ b/src/Docker/Runner/DataLoader/NullDataLoader.php
@@ -4,6 +4,7 @@ namespace Keboola\DockerBundle\Docker\Runner\DataLoader;
 
 use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Docker\OutputFilter\OutputFilterInterface;
+use Keboola\InputMapping\Reader\State\InputTableStateList;
 use Keboola\StorageApi\Client;
 use Psr\Log\LoggerInterface;
 

--- a/src/Docker/Runner/DataLoader/NullDataLoader.php
+++ b/src/Docker/Runner/DataLoader/NullDataLoader.php
@@ -16,6 +16,7 @@ class NullDataLoader implements DataLoaderInterface
 
     public function loadInputData(InputTableStateList $inputTableStateList)
     {
+        return new InputTableStateList([]);
     }
 
     public function storeOutput()

--- a/src/Docker/Runner/Output.php
+++ b/src/Docker/Runner/Output.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\DockerBundle\Docker\Runner;
 
+use Keboola\InputMapping\Reader\State\InputTableStateList;
 use Keboola\OutputMapping\DeferredTasks\LoadTableQueue;
 
 class Output
@@ -10,26 +11,26 @@ class Output
      * @var array
      */
     private $images = [];
-
     /**
      * @var string
      */
     private $output;
-
     /**
      * @var string
      */
     private $configVersion;
-
     /**
      * @var ?LoadTableQueue
      */
     private $tableQueue;
-
     /**
      * @var StateFile
      */
     private $stateFile;
+    /**
+     * @var InputTableStateList
+     */
+    private $inputTableStateList;
 
     /**
      * Output constructor.
@@ -43,7 +44,7 @@ class Output
         $this->images = $images;
         $this->output = $output;
         $this->configVersion = $configVersion;
-        $this->stateFile  = $stateFile;
+        $this->stateFile = $stateFile;
     }
 
     /**
@@ -76,6 +77,22 @@ class Output
     public function setTableQueue($tableQueue)
     {
         $this->tableQueue = $tableQueue;
+    }
+
+    /**
+     * @param InputTableStateList $inputTableStateList
+     */
+    public function setInputTableStateList(InputTableStateList $inputTableStateList)
+    {
+        $this->inputTableStateList = $inputTableStateList;
+    }
+
+    /**
+     * @return InputTableStateList
+     */
+    public function getInputTableStateList()
+    {
+        return $this->inputTableStateList;
     }
 
     public function getTableQueue()

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -131,7 +131,11 @@ class StateFile
         $configuration->setComponentId($this->componentId);
         $configuration->setConfigurationId($this->configurationId);
         try {
-            $encryptedStateData = $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class);
+            if ($this->currentState !== null) {
+                $encryptedStateData = $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class);
+            } else {
+                $encryptedStateData = [];
+            }
             if ($this->configurationRowId) {
                 $configurationRow = new ConfigurationRow($configuration);
                 $configurationRow->setRowId($this->configurationRowId);

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -131,6 +131,7 @@ class StateFile
         $configuration->setComponentId($this->componentId);
         $configuration->setConfigurationId($this->configurationId);
         try {
+            var_dump($this->currentState);
             $encryptedStateData = $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class);
             if ($this->configurationRowId) {
                 $configurationRow = new ConfigurationRow($configuration);

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -131,7 +131,6 @@ class StateFile
         $configuration->setComponentId($this->componentId);
         $configuration->setConfigurationId($this->configurationId);
         try {
-            var_dump($this->currentState);
             $encryptedStateData = $this->encryptorFactory->getEncryptor()->encrypt($this->currentState, ProjectWrapper::class);
             if ($this->configurationRowId) {
                 $configurationRow = new ConfigurationRow($configuration);

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -17,13 +17,13 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class StateFile
 {
-    const COMPONENT_NAMESPACE = 'component';
+    const NAMESPACE_COMPONENT = 'component';
 
-    const STORAGE_NAMESPACE = 'storage';
+    const NAMESPACE_STORAGE = 'storage';
 
-    const INPUT_NAMESPACE = 'input';
+    const NAMESPACE_INPUT = 'input';
 
-    const TABLES_NAMESPACE = 'tables';
+    const NAMESPACE_TABLES = 'tables';
 
     /**
      * @var string
@@ -92,8 +92,8 @@ class StateFile
         $this->componentId = $componentId;
         $this->configurationId = $configurationId;
         $this->configurationRowId = $configurationRowId;
-        if (isset($state[self::COMPONENT_NAMESPACE])) {
-            $this->state = $state[self::COMPONENT_NAMESPACE];
+        if (isset($state[self::NAMESPACE_COMPONENT])) {
+            $this->state = $state[self::NAMESPACE_COMPONENT];
         } else {
             $this->state = $state;
         }
@@ -140,20 +140,20 @@ class StateFile
                 $configurationRow = new ConfigurationRow($configuration);
                 $configurationRow->setRowId($this->configurationRowId);
                 $configurationRow->setState([
-                    self::COMPONENT_NAMESPACE => $encryptedStateData,
-                    self::STORAGE_NAMESPACE => [
-                        self::INPUT_NAMESPACE => [
-                            self::TABLES_NAMESPACE => $inputTableStateList->jsonSerialize()
+                    self::NAMESPACE_COMPONENT => $encryptedStateData,
+                    self::NAMESPACE_STORAGE => [
+                        self::NAMESPACE_INPUT => [
+                            self::NAMESPACE_TABLES => $inputTableStateList->jsonSerialize()
                         ]
                     ]
                 ]);
                 $components->updateConfigurationRow($configurationRow);
             } else {
                 $configuration->setState([
-                    self::COMPONENT_NAMESPACE => $encryptedStateData,
-                    self::STORAGE_NAMESPACE => [
-                        self::INPUT_NAMESPACE => [
-                            self::TABLES_NAMESPACE => $inputTableStateList->jsonSerialize()
+                    self::NAMESPACE_COMPONENT => $encryptedStateData,
+                    self::NAMESPACE_STORAGE => [
+                        self::NAMESPACE_INPUT => [
+                            self::NAMESPACE_TABLES => $inputTableStateList->jsonSerialize()
                         ]
                     ]
                 ]);

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -17,13 +17,13 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class StateFile
 {
-    const COMPONENT_NAMESPACE_PREFIX = 'component';
+    const COMPONENT_NAMESPACE = 'component';
 
-    const STORAGE_NAMESPACE_PREFIX = 'storage';
+    const STORAGE_NAMESPACE = 'storage';
 
-    const INPUT_NAMESPACE_PREFIX = 'input';
+    const INPUT_NAMESPACE = 'input';
 
-    const TABLES_NAMESPACE_PREFIX = 'tables';
+    const TABLES_NAMESPACE = 'tables';
 
     /**
      * @var string
@@ -92,8 +92,8 @@ class StateFile
         $this->componentId = $componentId;
         $this->configurationId = $configurationId;
         $this->configurationRowId = $configurationRowId;
-        if (isset($state[self::COMPONENT_NAMESPACE_PREFIX])) {
-            $this->state = $state[self::COMPONENT_NAMESPACE_PREFIX];
+        if (isset($state[self::COMPONENT_NAMESPACE])) {
+            $this->state = $state[self::COMPONENT_NAMESPACE];
         } else {
             $this->state = $state;
         }
@@ -140,20 +140,20 @@ class StateFile
                 $configurationRow = new ConfigurationRow($configuration);
                 $configurationRow->setRowId($this->configurationRowId);
                 $configurationRow->setState([
-                    self::COMPONENT_NAMESPACE_PREFIX => $encryptedStateData,
-                    self::STORAGE_NAMESPACE_PREFIX => [
-                        self::INPUT_NAMESPACE_PREFIX => [
-                            self::TABLES_NAMESPACE_PREFIX => $inputTableStateList->jsonSerialize()
+                    self::COMPONENT_NAMESPACE => $encryptedStateData,
+                    self::STORAGE_NAMESPACE => [
+                        self::INPUT_NAMESPACE => [
+                            self::TABLES_NAMESPACE => $inputTableStateList->jsonSerialize()
                         ]
                     ]
                 ]);
                 $components->updateConfigurationRow($configurationRow);
             } else {
                 $configuration->setState([
-                    self::COMPONENT_NAMESPACE_PREFIX => $encryptedStateData,
-                    self::STORAGE_NAMESPACE_PREFIX => [
-                        self::INPUT_NAMESPACE_PREFIX => [
-                            self::TABLES_NAMESPACE_PREFIX => $inputTableStateList->jsonSerialize()
+                    self::COMPONENT_NAMESPACE => $encryptedStateData,
+                    self::STORAGE_NAMESPACE => [
+                        self::INPUT_NAMESPACE => [
+                            self::TABLES_NAMESPACE => $inputTableStateList->jsonSerialize()
                         ]
                     ]
                 ]);


### PR DESCRIPTION
Nejvíc zabíraj testy, `RunnerTest::testRunAdaptiveInputMapping` a `RunnerConfigRowsTest:testRunRowAdaptiveInputMapping`, který oba dělaj totéž, ale jedno na configu a druhé na row. Zbytek je celkem straightforward.

Trochu si nejsem jistej implementací v `Runner::runRow` a `StateFile::persistState`, ale v tom druhém případě by pomohlo od sebe rozdělit  `State` (načítání a ukládání z/do configu) a `ComponentState` (`config.json` na disku) a mohlo by to bejt zase čistý. 