### PR TITLE
use image digests

### DIFF
--- a/Tests/Docker/Image/AWSElasticContainerRegistryTest.php
+++ b/Tests/Docker/Image/AWSElasticContainerRegistryTest.php
@@ -7,6 +7,7 @@ use Keboola\DockerBundle\Docker\Image\AWSElasticContainerRegistry;
 use Keboola\DockerBundle\Docker\ImageFactory;
 use Keboola\DockerBundle\Exception\LoginFailedException;
 use Keboola\DockerBundle\Tests\BaseImageTest;
+use Keboola\DockerBundle\Tests\Docker\ImageTest;
 use Keboola\Temp\Temp;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -16,6 +17,7 @@ use Symfony\Component\Process\Process;
 
 class AWSElasticContainerRegistryTest extends BaseImageTest
 {
+
     public function testMissingCredentials()
     {
         putenv('AWS_ACCESS_KEY_ID=');
@@ -133,10 +135,11 @@ class AWSElasticContainerRegistryTest extends BaseImageTest
         self::assertEquals(AWS_ECR_REGISTRY_URI . ':test-hash', $image->getFullImageId());
         self::assertTrue($testHandler->hasNotice(
             'Using image ' . AWS_ECR_REGISTRY_URI .
-            ':test-hash with repo-digest 061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing@sha256:a89486bee7cadd59a966500cd837e0cea70a7989de52636652ae9fccfc958c9a'
+            ':test-hash with repo-digest 061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing@sha256:' .
+            ImageTest::TEST_HASH_DIGEST
         ));
         self::assertEquals(
-            ['061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing@sha256:a89486bee7cadd59a966500cd837e0cea70a7989de52636652ae9fccfc958c9a'],
+            ['061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing@sha256:' . ImageTest::TEST_HASH_DIGEST],
             $image->getImageDigests()
         );
 

--- a/Tests/Docker/ImageTest.php
+++ b/Tests/Docker/ImageTest.php
@@ -121,8 +121,8 @@ class ImageTest extends BaseImageTest
         $image = ImageFactory::getImage($this->getEncryptor(), $logger, $imageConfig, new Temp(), true);
         $image->prepare([]);
         self::assertTrue($logger->hasNoticeThatContains(
-            'Image "061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" ' .
-            'is not current, pulling new copy.'
+            'Digest "a89486bee7cadd59a966500cd837e0cea70a7989de52636652ae9fccfc958c9a" for image ' .
+            '"061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" not found.'
         ));
     }
 
@@ -145,8 +145,8 @@ class ImageTest extends BaseImageTest
         $image = ImageFactory::getImage($this->getEncryptor(), $logger, $imageConfig, new Temp(), true);
         $image->prepare([]);
         self::assertFalse($logger->hasNoticeThatContains(
-            'Image "061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" ' .
-            'is not current, pulling new copy.'
+            'Digest "a89486bee7cadd59a966500cd837e0cea70a7989de52636652ae9fccfc958c9a" for image ' .
+            '"061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" not found.'
         ));
     }
 
@@ -179,8 +179,8 @@ class ImageTest extends BaseImageTest
         $image = ImageFactory::getImage($this->getEncryptor(), $logger, $imageConfig, new Temp(), true);
         $image->prepare([]);
         self::assertTrue($logger->hasNoticeThatContains(
-            'Image "061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" ' .
-            'is not current, pulling new copy.'
+            'Digest "' . $matches[1] . '" for image ' .
+            '"061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" not found.'
         ));
     }
 }

--- a/Tests/Docker/ImageTest.php
+++ b/Tests/Docker/ImageTest.php
@@ -9,9 +9,13 @@ use Keboola\DockerBundle\Docker\ImageFactory;
 use Keboola\DockerBundle\Tests\BaseImageTest;
 use Keboola\Temp\Temp;
 use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
+use Symfony\Component\Process\Process;
 
 class ImageTest extends BaseImageTest
 {
+    const TEST_HASH_DIGEST = 'a89486bee7cadd59a966500cd837e0cea70a7989de52636652ae9fccfc958c9a';
+
     public function testDockerHub()
     {
         $configuration = new Component([
@@ -97,5 +101,86 @@ class ImageTest extends BaseImageTest
         self::assertEquals("--username='cc' --password='bb' 'quay.io'", $image->getLoginParams());
         self::assertEquals("'quay.io'", $image->getLogoutParams());
         self::assertEquals('quay.io/keboola/docker-demo-private:latest', $image->getFullImageId());
+    }
+
+    public function testImageDigestNotPulled()
+    {
+        $command = new Process('docker rmi 061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash');
+        $command->run();
+        $imageConfig = new Component([
+            'data' => [
+                'definition' => [
+                    'type' => 'aws-ecr',
+                    'uri' => '061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing',
+                    'digest' => self::TEST_HASH_DIGEST,
+                    'tag' => 'test-hash',
+                ],
+            ],
+        ]);
+        $logger = new TestLogger();
+        $image = ImageFactory::getImage($this->getEncryptor(), $logger, $imageConfig, new Temp(), true);
+        $image->prepare([]);
+        self::assertTrue($logger->hasNoticeThatContains(
+            'Image "061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" ' .
+            'is not current, pulling new copy.'
+        ));
+    }
+
+    public function testImageDigestPulled()
+    {
+
+        $imageConfig = new Component([
+            'data' => [
+                'definition' => [
+                    'type' => 'aws-ecr',
+                    'uri' => '061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing',
+                    'digest' => self::TEST_HASH_DIGEST,
+                    'tag' => 'test-hash',
+                ],
+            ],
+        ]);
+        $image = ImageFactory::getImage($this->getEncryptor(), new NullLogger(), $imageConfig, new Temp(), true);
+        $image->prepare([]);
+        $logger = new TestLogger();
+        $image = ImageFactory::getImage($this->getEncryptor(), $logger, $imageConfig, new Temp(), true);
+        $image->prepare([]);
+        self::assertFalse($logger->hasNoticeThatContains(
+            'Image "061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" ' .
+            'is not current, pulling new copy.'
+        ));
+    }
+
+    public function testImageDigestInvalid()
+    {
+        $imageConfig = new Component([
+            'data' => [
+                'definition' => [
+                    'type' => 'aws-ecr',
+                    'uri' => '061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing',
+                    'digest' => self::TEST_HASH_DIGEST,
+                    'tag' => 'latest',
+                ],
+            ],
+        ]);
+        $image = ImageFactory::getImage($this->getEncryptor(), new NullLogger(), $imageConfig, new Temp(), true);
+        $image->prepare([]);
+        preg_match('#@sha256:(.*)$#', $image->getImageDigests()[0], $matches);
+        $imageConfig = new Component([
+            'data' => [
+                'definition' => [
+                    'type' => 'aws-ecr',
+                    'uri' => '061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing',
+                    'digest' => $matches[1],
+                    'tag' => 'test-hash',
+                ],
+            ],
+        ]);
+        $logger = new TestLogger();
+        $image = ImageFactory::getImage($this->getEncryptor(), $logger, $imageConfig, new Temp(), true);
+        $image->prepare([]);
+        self::assertTrue($logger->hasNoticeThatContains(
+            'Image "061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash" ' .
+            'is not current, pulling new copy.'
+        ));
     }
 }

--- a/src/Docker/Image.php
+++ b/src/Docker/Image.php
@@ -212,7 +212,9 @@ abstract class Image
             }
         });
         if (!in_array($this->digest, $digests)) {
-            $this->logger->notice(sprintf('Image "%s" is not current, pulling new copy.', $this->getFullImageId()));
+            $this->logger->notice(
+                sprintf('Digest "%s" for image "%s" not found.', $this->digest, $this->getFullImageId())
+            );
             $this->pullImage();
         }
     }

--- a/src/Docker/Image.php
+++ b/src/Docker/Image.php
@@ -29,6 +29,11 @@ abstract class Image
     protected $tag = "latest";
 
     /**
+     * @var string
+     */
+    protected $digest;
+
+    /**
      * @var ObjectEncryptor
      */
     protected $encryptor;
@@ -86,10 +91,11 @@ abstract class Image
         $this->encryptor = $encryptor;
         $this->component = $component;
         $this->logger = $logger;
-        $this->imageId = $component->getImageDefinition()["uri"];
+        $this->imageId = $component->getImageDefinition()['uri'];
         if (!empty($component->getImageDefinition()['tag'])) {
             $this->tag = $component->getImageDefinition()['tag'];
         }
+        $this->digest = $component->getImageDefinition()['digest'];
     }
 
     /**
@@ -170,8 +176,45 @@ abstract class Image
      */
     public function prepare(array $configData)
     {
+        /**
+         * Because we still run images by tag, we need to check that the tag matches the digest.
+         * One way to do this can be to docker list images with tag and check their digest. Unfortunately this
+         * does not work because of bug https://github.com/docker/cli/issues/728
+         *
+         * I.e. running
+         * `docker images --digests someImage@sha256:someDigest`
+         * returns the image digest and no tags, and running
+         * `docker images --digests someImage:someTag`
+         * return the image tag and no digests. This is also probably in a way intentional as suggested here
+         * https://success.docker.com/article/images-tagging-vs-digests
+         *
+         * Therefor, one would be to do
+         * `docker images someImage:someTag --no-trunc --format "{{.ID}}"`
+         * and
+         * `docker images someImage@sha:someDigest --no-trunc --format "{{.ID}}"`
+         * and verify that the IDs match.
+         *
+         * This requires 2 docker lists which take time, to do it with one command, we can use:
+         * `docker image inspect someImage:someTag -f '{{.RepoDigests}}'`
+         * which returns a list of digests associated to a given tag. Which is what image->getDigests() does.
+         */
         $this->configData = $configData;
-        $this->pullImage();
+        $digests = $this->getImageDigests();
+        array_walk($digests, function (&$value) {
+            // the value looks like:
+            // 061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing@sha256:abcdefghxxxxxxxxxxxxxxxxxxxx
+            if (preg_match('#@sha256:(.*)$#', $value, $matches)) {
+                $value = $matches[1];
+            } else {
+                // whatever it is, ignore it silently and download new image copy
+                // (this is the case when image does not exist at all)
+                $value = '';
+            }
+        });
+        if (!in_array($this->digest, $digests)) {
+            $this->logger->notice(sprintf('Image "%s" is not current, pulling new copy.', $this->getFullImageId()));
+            $this->pullImage();
+        }
     }
 
     public function getSourceComponent()
@@ -213,8 +256,8 @@ abstract class Image
                 }
                 $this->imageDigests = $inspect[0]['RepoDigests'];
             } catch (\Exception $e) {
-                $this->logger->error("Failed to get hash for image " . $this->getFullImageId());
-                $this->imageDigests = ['err'];
+                $this->logger->notice("Failed to get hash for image " . $this->getFullImageId());
+                $this->imageDigests = [];
             }
         }
         return $this->imageDigests;


### PR DESCRIPTION
fixes https://github.com/keboola/docker-bundle/issues/375

feat: do not pull image when tag and digest matches existing
fix: don't show 'Failed to get hash for image' as error, because it simply means that the image is not cached
fix: don't store fake 'err' digest to make digests reload after image is cached