### PR TITLE
Throw user exception if oauth_api version 2 is used

### DIFF
--- a/Tests/Executor/JobExecutorInlineConfigTest.php
+++ b/Tests/Executor/JobExecutorInlineConfigTest.php
@@ -167,7 +167,7 @@ class JobExecutorInlineConfigTest extends BaseExecutorTest
         $oauthStub->method('getDetail')->willReturn($credentialsEncrypted);
         $runner = $this->getRunner();
         // inject mock OAuth client inside Runner
-        $prop = new \ReflectionProperty($runner, 'oauthClient');
+        $prop = new \ReflectionProperty($runner, 'oauthClient3');
         $prop->setAccessible(true);
         $prop->setValue($runner, $oauthStub);
 
@@ -241,7 +241,7 @@ class JobExecutorInlineConfigTest extends BaseExecutorTest
         $oauthStub->method('getDetail')->willReturn($credentialsEncrypted);
         // inject mock OAuth client inside Runner
         $runner = $this->getRunner();
-        $prop = new \ReflectionProperty($runner, 'oauthClient');
+        $prop = new \ReflectionProperty($runner, 'oauthClient3');
         $prop->setAccessible(true);
         $prop->setValue($runner, $oauthStub);
 

--- a/Tests/Executor/JobExecutorInlineConfigTest.php
+++ b/Tests/Executor/JobExecutorInlineConfigTest.php
@@ -142,6 +142,7 @@ class JobExecutorInlineConfigTest extends BaseExecutorTest
     {
         $data = $this->getJobParameters();
         $data['params']['configData']['authorization']['oauth_api']['id'] = '12345';
+        $data['params']['configData']['authorization']['oauth_api']['version'] = 3;
         $data['params']['configData']['storage'] = [];
         $data['params']['configData']['parameters']['script'] = [
             'from pathlib import Path',
@@ -214,6 +215,7 @@ class JobExecutorInlineConfigTest extends BaseExecutorTest
         $data = $this->getJobParameters();
         $data['params']['component'] = 'keboola.python-transformation';
         $data['params']['configData']['authorization']['oauth_api']['id'] = '12345';
+        $data['params']['configData']['authorization']['oauth_api']['version'] = 3;
         $data['params']['configData']['storage'] = [];
         $data['params']['configData']['parameters']['script'] = [
             'from pathlib import Path',

--- a/Tests/Runner/AuthorizationTest.php
+++ b/Tests/Runner/AuthorizationTest.php
@@ -39,7 +39,10 @@ class AuthorizationTest extends BaseRunnerTest
             ->method('getDetail')
             ->with('keboola.docker-demo', 'whatever')
             ->will(self::returnValue($oauthResponse));
-        $config = ['oauth_api' => ['id' => 'whatever']];
+        $config = ['oauth_api' => [
+            'id' => 'whatever',
+            'version' => 3
+        ]];
 
         /** @var Credentials $oauthClientStub */
         $auth = new Authorization($oauthClientStub, $oauthClientStub, $encryptorFactory->getEncryptor(), 'keboola.docker-demo');
@@ -56,17 +59,6 @@ class AuthorizationTest extends BaseRunnerTest
         $oauthClientStub2 = self::getMockBuilder(Credentials::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $credentials2 = [
-            'id' => 'test-credential-1',
-            '#data' => '{"access_token":"abcd","token_type":"bearer","uid":"efgh"}',
-            'oauthVersion' => '2.0',
-            '#appSecret' => '654321',
-        ];
-        $oauthResponse2 = $encryptorFactory->getEncryptor()->encrypt($credentials2);
-        $oauthClientStub2->expects(self::once())
-            ->method('getDetail')
-            ->with('keboola.docker-demo', 'whatever')
-            ->will(self::returnValue($oauthResponse2));
         $oauthClientStub3 = self::getMockBuilder(Credentials::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -89,12 +81,6 @@ class AuthorizationTest extends BaseRunnerTest
         $auth = new Authorization($oauthClientStub2, $oauthClientStub3, $encryptorFactory->getEncryptor(), 'keboola.docker-demo');
         self::assertEquals(
             $credentials3,
-            $auth->getAuthorization($config)['oauth_api']['credentials']
-        );
-        $config = ['oauth_api' => ['id' => 'whatever', 'version' => '2']];
-        $auth = new Authorization($oauthClientStub2, $oauthClientStub3, $encryptorFactory->getEncryptor(), 'keboola.docker-demo');
-        self::assertEquals(
-            $credentials2,
             $auth->getAuthorization($config)['oauth_api']['credentials']
         );
     }
@@ -124,7 +110,10 @@ class AuthorizationTest extends BaseRunnerTest
             ->method('getDetail')
             ->with('keboola.docker-demo', 'test-credentials-45')
             ->will(self::returnValue($oauthResponse));
-        $config = ['authorization' => ['oauth_api' => ['id' => 'test-credentials-45']]];
+        $config = ['authorization' => ['oauth_api' => [
+            'id' => 'test-credentials-45',
+            'version' => 3
+        ]]];
 
         $temp = new Temp();
         /** @var Credentials $oauthClientStub */
@@ -178,7 +167,10 @@ class AuthorizationTest extends BaseRunnerTest
             'appKey' => '123456',
             '#appSecret' => '654321',
         ];
-        $config = ['oauth_api' => ['credentials' => $credentials]];
+        $config = ['oauth_api' => [
+            'credentials' => $credentials,
+            'version' => 3
+        ]];
 
         $oauthClientStub = self::getMockBuilder(Credentials::class)
             ->disableOriginalConstructor()
@@ -195,7 +187,10 @@ class AuthorizationTest extends BaseRunnerTest
     {
         $encryptorFactory = $this->getEncryptorFactory();
         $encryptorFactory->setComponentId('keboola.docker-demo');
-        $config = ['oauth_api' => ['id' => 'test-credentials-45']];
+        $config = ['oauth_api' => [
+            'id' => 'test-credentials-45',
+            'version' => 3
+        ]];
 
         $oauthClientStub = self::getMockBuilder(Credentials::class)
             ->disableOriginalConstructor()
@@ -215,7 +210,10 @@ class AuthorizationTest extends BaseRunnerTest
     {
         $encryptorFactory = $this->getEncryptorFactory();
         $encryptorFactory->setComponentId('keboola.docker-demo');
-        $config = ['oauth_api' => ['id' => 'test-credentials-45']];
+        $config = ['oauth_api' => [
+            'id' => 'test-credentials-45',
+            'version' => 3
+        ]];
 
         $oauthClientStub = self::getMockBuilder(Credentials::class)
             ->disableOriginalConstructor()
@@ -248,7 +246,12 @@ class AuthorizationTest extends BaseRunnerTest
             'appKey' => '123456',
             '#appSecret' => '654321',
         ];
-        $config = ['oauth_api' => ['credentials' => $encryptorFactory->getEncryptor()->encrypt($credentials)]];
+        $config = ['oauth_api' => [
+            'credentials' => $encryptorFactory->getEncryptor()->encrypt($credentials),
+            'version' => 3
+        ]];
+        $expectedConfig = $config;
+        unset($expectedConfig['oauth_api']['version']);
 
         $oauthClientStub = self::getMockBuilder(Credentials::class)
             ->disableOriginalConstructor()
@@ -256,7 +259,7 @@ class AuthorizationTest extends BaseRunnerTest
         /** @var Credentials $oauthClientStub */
         $auth = new Authorization($oauthClientStub, $oauthClientStub, $encryptorFactory->getEncryptor(), 'keboola.docker-demo');
         self::assertEquals(
-            $config,
+            $expectedConfig,
             $auth->getAuthorization($config)
         );
     }
@@ -279,7 +282,10 @@ class AuthorizationTest extends BaseRunnerTest
             'appKey' => '123456',
             '#appSecret' => '654321',
         ];
-        $config = ['authorization' => ['oauth_api' => ['credentials' => $credentials]]];
+        $config = ['authorization' => ['oauth_api' => [
+            'credentials' => $credentials,
+            'version' => 3
+        ]]];
 
         $temp = new Temp();
         $oauthClientStub = self::getMockBuilder(Credentials::class)

--- a/Tests/Runner/AuthorizationTest.php
+++ b/Tests/Runner/AuthorizationTest.php
@@ -324,4 +324,26 @@ class AuthorizationTest extends BaseRunnerTest
         ];
         self::assertEquals($sampleData, $data);
     }
+
+    public function testOauthV2DeprecationMessage()
+    {
+        self::expectException(UserException::class);
+        self::expectExceptionMessage('OAuth Broker v2 has been deprecated on September 30, 2019. https://status.keboola.com/end-of-life-old-oauth-broker');
+
+        $encryptorFactory = $this->getEncryptorFactory();
+        $encryptorFactory->setComponentId('keboola.docker-demo');
+        $config = [
+            'oauth_api' => [
+                'id' => 'test-deprecated-credentials',
+                'version' => 2
+            ]
+        ];
+
+        $oauthClientStub = self::getMockBuilder(Credentials::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var Credentials $oauthClientStub */
+        $auth = new Authorization($oauthClientStub, $oauthClientStub, $encryptorFactory->getEncryptor(), 'keboola.docker-demo');
+        $auth->getAuthorization($config);
+    }
 }

--- a/Tests/Runner/AuthorizationTest.php
+++ b/Tests/Runner/AuthorizationTest.php
@@ -52,39 +52,6 @@ class AuthorizationTest extends BaseRunnerTest
         );
     }
 
-    public function testOauthDecryptVersions()
-    {
-        $encryptorFactory = $this->getEncryptorFactory();
-        $encryptorFactory->setComponentId('keboola.docker-demo');
-        $oauthClientStub2 = self::getMockBuilder(Credentials::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $oauthClientStub3 = self::getMockBuilder(Credentials::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $credentials3 = [
-            'id' => 'test-credentials-2',
-            'created' => '2016-02-09 09:47:16',
-            '#data' => '{"access_token":"xyz"}',
-            'appKey' => '123456',
-            '#appSecret' => 'abcdef',
-        ];
-        $oauthResponse3 = $encryptorFactory->getEncryptor()->encrypt($credentials3);
-        $oauthClientStub3->expects(self::once())
-            ->method('getDetail')
-            ->with('keboola.docker-demo', 'whatever')
-            ->will(self::returnValue($oauthResponse3));
-
-        /** @var Credentials $oauthClientStub2 */
-        /** @var Credentials $oauthClientStub3 */
-        $config = ['oauth_api' => ['id' => 'whatever', 'version' => '3']];
-        $auth = new Authorization($oauthClientStub2, $oauthClientStub3, $encryptorFactory->getEncryptor(), 'keboola.docker-demo');
-        self::assertEquals(
-            $credentials3,
-            $auth->getAuthorization($config)['oauth_api']['credentials']
-        );
-    }
-
     public function testOauthConfigDecrypt()
     {
         $encryptorFactory = $this->getEncryptorFactory();

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -2046,7 +2046,8 @@ class RunnerTest extends BaseRunnerTest
                     'credentials' => [
                         '#three' => 'foo',
                         'four' => 'anotherFoo'
-                    ]
+                    ],
+                    'version' => 3
                 ]
             ]
         ];

--- a/src/Docker/Runner/Authorization.php
+++ b/src/Docker/Runner/Authorization.php
@@ -49,7 +49,7 @@ class Authorization
         if (isset($configData['oauth_api']['version']) && ($configData['oauth_api']['version'] == 3)) {
             $client = $this->oauthClientV3;
         } else {
-            $client = $this->oauthClient;
+            throw new UserException('OAuth Broker v2 has been deprecated on September 30, 2019. https://status.keboola.com/end-of-life-old-oauth-broker');
         }
         if (isset($configData['oauth_api']['id'])) {
             // read authorization from API


### PR DESCRIPTION
Fixes: #440

Changes:

- Throw user exception if oauth_api version 2 is used

---
Najprv som malicko poladil testy, nech sa vsetko testuje s verziou 3. Potom som pridal user exception, ked sa zavola `getAuthorization ` a je tam `oauth_api.version` 2.