### PR TITLE
Add missing sudo command

### DIFF
--- a/Tests/Docker/ImageTest.php
+++ b/Tests/Docker/ImageTest.php
@@ -52,7 +52,7 @@ class ImageTest extends BaseImageTest
 
     public function testImageDigestNotPulled()
     {
-        $command = new Process('docker rmi 061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash');
+        $command = new Process('sudo docker rmi 061240556736.dkr.ecr.us-east-1.amazonaws.com/docker-testing:test-hash');
         $command->run();
         $imageConfig = new Component([
             'data' => [


### PR DESCRIPTION
Related to: https://github.com/keboola/docker-runner-router/issues/1

Changes:

- Add missing sudo command

---
Ten test sa choval hodne zvlastne. Samotny, na prvy raz presiel. No napriklad s `--filter ImageTest` uz nie.