### PR TITLE
Try to get "command to get host ip" from env, otherwise use default

### DIFF
--- a/Tests/BaseRunnerTest.php
+++ b/Tests/BaseRunnerTest.php
@@ -135,7 +135,6 @@ abstract class BaseRunnerTest extends TestCase
             $this->loggersServiceStub,
             "dummy",
             ['cpu_count' => 2],
-            RUNNER_COMMAND_TO_GET_HOST_IP,
             RUNNER_MIN_LOG_PORT,
             RUNNER_MAX_LOG_PORT
         );

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -93,7 +93,6 @@ class Runner
      * @param LoggersService $loggersService
      * @param string $oauthApiUrl
      * @param array $instanceLimits
-     * @param string $commandToGetHostIp
      * @param int $minLogPort
      * @param int $maxLogPort
      */
@@ -103,7 +102,6 @@ class Runner
         LoggersService $loggersService,
         $oauthApiUrl,
         array $instanceLimits,
-        $commandToGetHostIp = 'ip -4 addr show docker0 | grep -Po \'inet \K[\d.]+\'',
         $minLogPort = 12202,
         $maxLogPort = 13202
     ) {
@@ -119,9 +117,18 @@ class Runner
         ]);
         $this->loggersService = $loggersService;
         $this->instanceLimits = $instanceLimits;
-        $this->commandToGetHostIp = $commandToGetHostIp;
+        $this->commandToGetHostIp = $this->getCommandToGetHostIp();
         $this->minLogPort = $minLogPort;
         $this->maxLogPort = $maxLogPort;
+    }
+
+    private function getCommandToGetHostIp()
+    {
+        if (getenv('RUNNER_COMMAND_TO_GET_HOST_IP')) {
+            return getenv('RUNNER_COMMAND_TO_GET_HOST_IP');
+        }
+
+        return 'ip -4 addr show docker0 | grep -Po \'inet \K[\d.]+\'';
     }
 
     /**


### PR DESCRIPTION
Related: https://github.com/keboola/docker-runner-router/issues/3

Changes:

- remove "commandToGetHostIp" from constructor, try to load it from env

---

Toto sa mi zda lepsie.

Ak to nechceme posielat do mastra, rebasnem to  na tu druhu branch.