### PR TITLE
Termination - restart job if docker daemon not available

### DIFF
--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -340,7 +340,7 @@ class Container
         ];
 
         // killed containers
-        if ($process->getExitCode() == 137) {
+        if (in_array($process->getExitCode(), [137, 125])) {
             // this catches the timeout from `sudo timeout`
             if ($duration >= $this->getImage()->getSourceComponent()->getProcessTimeout()) {
                 throw new UserException(

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -339,7 +339,7 @@ class Container
             ],
         ];
 
-        // killed containers
+        // killed container or docker socket not available (instance termination)
         if (in_array($process->getExitCode(), [137, 125])) {
             // this catches the timeout from `sudo timeout`
             if ($duration >= $this->getImage()->getSourceComponent()->getProcessTimeout()) {


### PR DESCRIPTION
Related to: https://github.com/keboola/docker-runner-router/issues/15
FIXES: https://github.com/keboola/docker-bundle/issues/428

Nenašel jsem jestli se to nějak testuje, moc to ale asi nejde. Tohle bych pak mergnul do syrup-v11 pro dockerized runner a ten updatnul na tuhle změnu. Nebo by to mělo jít i do stávajícího masteru? pak bych to udělal obráceně a ten syrup-v11 nad to pak rebasnul po merge.