### PR TITLE
fix: legacy encrypt API call

### DIFF
--- a/Tests/Controller/ActionControllerTest.php
+++ b/Tests/Controller/ActionControllerTest.php
@@ -5,7 +5,6 @@ namespace Keboola\DockerBundle\Tests\Controller;
 use Keboola\DockerBundle\Controller\ActionController;
 use Keboola\ObjectEncryptor\ObjectEncryptor;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
-use Keboola\ObjectEncryptor\Wrapper\ComponentWrapper;
 use Keboola\StorageApi\Client;
 use Keboola\DockerBundle\Service\StorageApiService;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -508,7 +507,7 @@ class ActionControllerTest extends WebTestCase
         $encryptorFactory->setProjectId('123');
         $encryptorFactory->setComponentId('dca-custom-science-python');
         $encryptorFactory->setStackId(parse_url($container->getParameter('storage_api.url'), PHP_URL_HOST));
-        $encryptedPassword = $encryptorFactory->getEncryptor()->encrypt('password', ComponentWrapper::class);
+        $encryptedPassword = $encryptorFactory->getEncryptor()->encrypt('password', $encryptorFactory->getEncryptor()->getRegisteredComponentWrapperClass());
         $request = $this->prepareRequest('decrypt', ["#password" => $encryptedPassword]);
 
         $container->set("syrup.storage_api", $this->getStorageServiceStubDcaPython());

--- a/Tests/Controller/ApiControllerTest.php
+++ b/Tests/Controller/ApiControllerTest.php
@@ -7,7 +7,6 @@ use Keboola\ObjectEncryptor\Legacy\Wrapper\BaseWrapper;
 use Keboola\ObjectEncryptor\Legacy\Wrapper\ComponentProjectWrapper;
 use Keboola\ObjectEncryptor\Legacy\Wrapper\ComponentWrapper as LegacyComponentWrapper;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
-use Keboola\ObjectEncryptor\Wrapper\ComponentWrapper;
 use Keboola\Syrup\Elasticsearch\JobMapper;
 use Keboola\Syrup\Job\Metadata\JobInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -327,7 +326,7 @@ class ApiControllerTest extends WebTestCase
         $encryptorFactory = clone self::$container->get('docker_bundle.object_encryptor_factory');
         $encryptorFactory->setComponentId('docker-config-encrypt-verify');
         $encryptorFactory->setStackId(parse_url(self::$container->getParameter('storage_api.url'), PHP_URL_HOST));
-        $encrypted = $encryptorFactory->getEncryptor()->encrypt('bar', ComponentWrapper::class);
+        $encrypted = $encryptorFactory->getEncryptor()->encrypt('bar', $encryptorFactory->getEncryptor()->getRegisteredComponentWrapperClass());
 
         $request = Request::create(
             "/docker/docker-config-encrypt-verify/run",

--- a/Tests/Executor/EncryptionTest.php
+++ b/Tests/Executor/EncryptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Keboola\DockerBundle\Tests\JobExecutorTest;
+namespace Keboola\DockerBundle\Tests\Executor;
 
 use Keboola\DockerBundle\Docker\Runner\StateFile;
 use Keboola\DockerBundle\Tests\BaseExecutorTest;

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -4,8 +4,6 @@ namespace Keboola\DockerBundle\Controller;
 
 use Keboola\DockerBundle\Docker\Runner;
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
-use Keboola\ObjectEncryptor\Wrapper\ComponentWrapper;
-use Keboola\ObjectEncryptor\Wrapper\ProjectWrapper;
 use Keboola\StorageApi\ClientException;
 use Keboola\Syrup\Elasticsearch\JobMapper;
 use Keboola\Syrup\Exception\ApplicationException;
@@ -253,9 +251,9 @@ class ApiController extends BaseApiController
         $encryptorFactory->setComponentId($componentId);
         if ($projectId) {
             $encryptorFactory->setProjectId($projectId);
-            $wrapperClass = ProjectWrapper::class;
+            $wrapperClass = $encryptorFactory->getEncryptor()->getRegisteredProjectWrapperClass();
         } else {
-            $wrapperClass = ComponentWrapper::class;
+            $wrapperClass = $encryptorFactory->getEncryptor()->getRegisteredComponentWrapperClass();
         }
 
         try {

--- a/src/Controller/PublicController.php
+++ b/src/Controller/PublicController.php
@@ -3,9 +3,6 @@
 namespace Keboola\DockerBundle\Controller;
 
 use Keboola\ObjectEncryptor\ObjectEncryptorFactory;
-use Keboola\ObjectEncryptor\Wrapper\ComponentWrapper;
-use Keboola\ObjectEncryptor\Wrapper\ConfigurationWrapper;
-use Keboola\ObjectEncryptor\Wrapper\ProjectWrapper;
 use Symfony\Component\HttpFoundation\Request;
 use Keboola\Syrup\Exception\UserException;
 

--- a/src/Controller/PublicController.php
+++ b/src/Controller/PublicController.php
@@ -37,14 +37,14 @@ class PublicController extends \Keboola\Syrup\Controller\PublicController
         if ($projectId && $configurationId) {
             $encryptorFactory->setProjectId($projectId);
             $encryptorFactory->setConfigurationId($configurationId);
-            $wrapperClassName = ConfigurationWrapper::class;
+            $wrapperClassName = $encryptorFactory->getEncryptor()->getRegisteredConfigurationWrapperClass();
         } elseif ($projectId) {
             $encryptorFactory->setProjectId($projectId);
-            $wrapperClassName = ProjectWrapper::class;
+            $wrapperClassName = $encryptorFactory->getEncryptor()->getRegisteredProjectWrapperClass();
         } elseif ($configurationId) {
             throw new UserException("The configId parameter must be used together with projectId.");
         } else {
-            $wrapperClassName = ComponentWrapper::class;
+            $wrapperClassName = $encryptorFactory->getEncryptor()->getRegisteredComponentWrapperClass();
         }
 
         $contentTypeHeader = $request->headers->get("Content-Type");


### PR DESCRIPTION
fixes incident https://keboola.slack.com/archives/CQB468K63/p1593113097024900?thread_ts=1592311989.039900&cid=CQB468K63

testy k tomu nejsou overim rucne po nasazeni na testing:
```
curl --location --request POST 'https://docker-runner.us-east-1.keboola-testing.com/docker/encrypt?componentId=test' \
--header 'Content-Type: application/json' \
--data-raw '{
    "#a": "b"
}'
```

coz dneska konci chybou https://my.papertrailapp.com/events?q=a879a32517ac8716092efeadc3b6764c