### PR TITLE
fix: image name can't be hardcoded

### DIFF
--- a/Tests/Docker/Image/AWSElasticContainerRegistryTest.php
+++ b/Tests/Docker/Image/AWSElasticContainerRegistryTest.php
@@ -147,8 +147,10 @@ class AWSElasticContainerRegistryTest extends BaseImageTest
             [AWS_ECR_REGISTRY_URI . '@sha256:' . ImageTest::TEST_HASH_DIGEST],
             $image->getImageDigests()
         );
+        $repoParts = explode('/', AWS_ECR_REGISTRY_URI);
+        array_shift($repoParts);
         self::assertEquals(
-            ['docker-testing@sha256:' . ImageTest::TEST_HASH_DIGEST],
+            [implode('/', $repoParts) . '@sha256:' . ImageTest::TEST_HASH_DIGEST],
             $image->getPrintableImageDigests()
         );
         (new Process('sudo docker rmi ' . AWS_ECR_REGISTRY_URI))->run();


### PR DESCRIPTION
omg, tak jeste jednou

https://keboola.atlassian.net/browse/PS-937

follow up to https://github.com/keboola/docker-bundle/pull/499

because this fails https://travis-ci.com/github/keboola/docker-runner-router/builds/185567739 because it uses different image for tests