### PR TITLE
fix: accept non-admin tokens too

### DIFF
--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -76,7 +76,7 @@ class ApiController extends BaseApiController
 
         try {
             $tokenInfo = $this->storageApi->verifyToken();
-            if ($tokenInfo['admin']['role'] === 'readOnly') {
+            if (!empty($tokenInfo['admin']['role']) && ($tokenInfo['admin']['role'] === 'readOnly')) {
                 throw new UserException('As a readOnly user you cannot run a job.');
             }
             if (isset($params["configData"])) {


### PR DESCRIPTION
vyfailoval request na testing orchestraci https://connection.keboola.com/admin/projects/395/orchestrations/292003114/jobs/645913900 protoze sekce `admin` je v tokeninfo jen pokud je to master token
https://my.papertrailapp.com/groups/23635/events?focus=1259848640311205912&q=program%3Aapi-f4477108-320d-42af-ab67-b3e025943673&selected=1259848640311205912

testy by to chytili, kdyby se spoustely :( 