### PR TITLE
fix: test assertion

### DIFF
--- a/Tests/Executor/JobExecutorStoredConfigTest.php
+++ b/Tests/Executor/JobExecutorStoredConfigTest.php
@@ -133,7 +133,7 @@ class JobExecutorStoredConfigTest extends BaseExecutorTest
         self::assertArrayHasKey('images', $ret);
         self::assertArrayHasKey('configVersion', $ret);
 
-        $csvData = $this->getClient()->getTableDataPreview('out.c-my-dev-branch-executor-test.output');
+        $csvData = $this->getClient()->getTableDataPreview(sprintf('out.c-%s-executor-test.output', $this->branchId));
         $data = Client::parseCsv($csvData);
         usort($data, function ($a, $b) {
             return strcmp($a['name'], $b['name']);


### PR DESCRIPTION
the assertion was wrong, but passing because the bucket and table existed. It existed because it's cleaned up before running the tests. When we changed branchname->branchid the bucket stopped to be cleaned and remained there until I cleaned it manually, which broke the tests.
