### PR TITLE
feat: no-internet network option

### DIFF
--- a/src/Docker/Component.php
+++ b/src/Docker/Component.php
@@ -225,7 +225,7 @@ class Component
 
     public function setNetworkType($value)
     {
-        if (!in_array($value, ['none', 'bridge'])) {
+        if (!in_array($value, ['none', 'bridge', 'no-internet'])) {
             throw new ApplicationException("Network mode $value is not supported.");
         } else {
             $this->networkType = $value;

--- a/src/Docker/Configuration/Component.php
+++ b/src/Docker/Configuration/Component.php
@@ -31,7 +31,7 @@ class Component extends Configuration
             ->variableNode('image_parameters')->defaultValue([])->end()
             ->scalarNode('network')
                 ->validate()
-                    ->ifNotInArray(['none', 'bridge'])
+                    ->ifNotInArray(['none', 'bridge', 'no-internet'])
                     ->thenInvalid('Invalid network type %s.')
                 ->end()
                 ->defaultValue('bridge')


### PR DESCRIPTION
Nová volba `no-internet` pro `network` config option. Developer Portal neřeším, je to pro ČSAS stack, kam se komponenty syncují manuálně. 

https://github.com/keboola/infrastructure-plugin-update-components/blob/900529c6e53d6f0d877dfcbef129ae439f42cf69/stacks/kbc-testing-azure-east-us-2.json#L80-L81

Naváže na to https://github.com/keboola/docker-runner-router/pull/121/.

https://keboola.atlassian.net/browse/SRE-1536