### PR TITLE
fix: don't block configurations with empty processed tags

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.171.2",
+            "version": "3.171.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "742663a85ec84647f74dea454d2dc45bba180f9d"
+                "reference": "848923bc9ce5f8c5ede2df7175b090e382bba699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/742663a85ec84647f74dea454d2dc45bba180f9d",
-                "reference": "742663a85ec84647f74dea454d2dc45bba180f9d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/848923bc9ce5f8c5ede2df7175b090e382bba699",
+                "reference": "848923bc9ce5f8c5ede2df7175b090e382bba699",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2020-12-18T19:12:13+00:00"
+            "time": "2020-12-22T21:56:27+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -1891,16 +1891,16 @@
         },
         {
             "name": "keboola/input-mapping",
-            "version": "12.0.0",
+            "version": "12.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "e70c35f9e046b853b7d3ab18ca494522c49b7889"
+                "reference": "1f9f6a98ecc3ca3144d38e0b62cc8bf6f68ec2d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/e70c35f9e046b853b7d3ab18ca494522c49b7889",
-                "reference": "e70c35f9e046b853b7d3ab18ca494522c49b7889",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/1f9f6a98ecc3ca3144d38e0b62cc8bf6f68ec2d8",
+                "reference": "1f9f6a98ecc3ca3144d38e0b62cc8bf6f68ec2d8",
                 "shasum": ""
             },
             "require": {
@@ -1934,7 +1934,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI input mapping and exporting to files",
-            "time": "2020-12-18T13:21:11+00:00"
+            "time": "2020-12-23T13:43:08+00:00"
         },
         {
             "name": "keboola/oauth-v2-php-client",


### PR DESCRIPTION
follow up to https://github.com/keboola/input-mapping/pull/80