### PR TITLE
Persistent ABS workspaces

### DIFF
--- a/Tests/Runner/DataLoaderPersistentABSWorkspaceTest.php
+++ b/Tests/Runner/DataLoaderPersistentABSWorkspaceTest.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace Keboola\DockerBundle\Tests\Runner;
+
+use Keboola\DockerBundle\Docker\Component;
+use Keboola\DockerBundle\Docker\JobDefinition;
+use Keboola\DockerBundle\Docker\OutputFilter\OutputFilter;
+use Keboola\DockerBundle\Docker\Runner\DataLoader\DataLoader;
+use Keboola\DockerBundle\Docker\Runner\WorkingDirectory;
+use Keboola\DockerBundle\Exception\ApplicationException;
+use Keboola\DockerBundle\Tests\BaseDataLoaderTest;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\Components;
+use Keboola\StorageApi\Metadata;
+use Keboola\StorageApi\Options\Components\Configuration;
+use Keboola\StorageApi\Options\Components\ListConfigurationWorkspacesOptions;
+use Keboola\StorageApi\Workspaces;
+use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\Temp\Temp;
+use Psr\Log\NullLogger;
+use Psr\Log\Test\TestLogger;
+
+class DataLoaderPersistentABSWorkspaceTest extends BaseDataLoaderTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->client = new Client([
+            'url' => STORAGE_API_URL_SYNAPSE,
+            'token' => STORAGE_API_TOKEN_SYNAPSE,
+        ]);
+        $this->metadata = new Metadata($this->client);
+        $this->temp = new Temp();
+        $this->temp->initRunFolder();
+        $this->workingDir = new WorkingDirectory($this->temp->getTmpFolder(), new NullLogger());
+        $this->workingDir->createWorkingDir();
+    }
+
+    public function testAbsWorkspaceNoConfig()
+    {
+        $component = new Component([
+            'id' => 'docker-demo',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'keboola/docker-demo',
+                    'tag' => 'master'
+                ],
+                'staging-storage' => [
+                    'input' => 'workspace-abs',
+                    'output' => 'workspace-abs',
+                ],
+            ],
+        ]);
+        $client = self::getMockBuilder(Client::class)
+            ->setConstructorArgs([[
+                'url' => STORAGE_API_URL_SYNAPSE,
+                'token' => STORAGE_API_TOKEN_SYNAPSE,
+            ]])
+            ->setMethods(['apiDelete'])
+            ->getMock();
+        $client->expects($this->once())->method('apiDelete')->with(self::stringContains('workspaces/'));
+        /** @var Client $client */
+        $clientWrapper = new ClientWrapper($client, null, null, '');
+        $logger = new TestLogger();
+        $dataLoader = new DataLoader(
+            $clientWrapper,
+            $logger,
+            $this->workingDir->getDataDir(),
+            new JobDefinition([], $component),
+            new OutputFilter()
+        );
+
+        $dataLoader->storeOutput();
+
+        $credentials = $dataLoader->getWorkspaceCredentials();
+        self::assertEquals(['connectionString', 'container'], array_keys($credentials));
+        self::assertStringStartsWith('BlobEndpoint=https://', $credentials['connectionString']);
+        self::assertTrue($logger->hasInfoThatContains('Created a new ephemeral workspace.'));
+        $dataLoader->cleanWorkspace();
+        // checked in mock that the workspace is deleted
+    }
+
+    public function testAbsWorkspaceConfigNoWorkspace()
+    {
+        $component = new Component([
+            'id' => 'keboola.runner-config-test',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'keboola/docker-demo',
+                    'tag' => 'master'
+                ],
+                'staging-storage' => [
+                    'input' => 'workspace-abs',
+                    'output' => 'workspace-abs',
+                ],
+            ],
+        ]);
+        $client = self::getMockBuilder(Client::class)
+            ->setConstructorArgs([[
+                'url' => STORAGE_API_URL_SYNAPSE,
+                'token' => STORAGE_API_TOKEN_SYNAPSE,
+            ]])
+            ->setMethods(['apiDelete'])
+            ->getMock();
+        $client->expects(self::never())->method('apiDelete');
+        /** @var Client $client */
+        $configuration = new Configuration();
+        $configuration->setConfiguration([]);
+        $configuration->setName('test-dataloader');
+        $configuration->setComponentId('keboola.runner-config-test');
+        $componentsApi = new Components($this->client);
+        $configurationId = $componentsApi->addConfiguration($configuration)['id'];
+        $clientWrapper = new ClientWrapper($client, null, null, '');
+        $logger = new TestLogger();
+        $dataLoader = new DataLoader(
+            $clientWrapper,
+            $logger,
+            $this->workingDir->getDataDir(),
+            new JobDefinition([], $component, $configurationId),
+            new OutputFilter()
+        );
+
+        $dataLoader->storeOutput();
+
+        $credentials = $dataLoader->getWorkspaceCredentials();
+        self::assertEquals(['connectionString', 'container'], array_keys($credentials));
+        self::assertStringStartsWith('BlobEndpoint=https://', $credentials['connectionString']);
+        $workspaces = $componentsApi->listConfigurationWorkspaces(
+            (new ListConfigurationWorkspacesOptions())
+                ->setComponentId('keboola.runner-config-test')
+                ->setConfigurationId($configurationId)
+        );
+        self::assertCount(1, $workspaces);
+        $dataLoader->cleanWorkspace();
+        // double check that workspace still exists
+        $workspaces = $componentsApi->listConfigurationWorkspaces(
+            (new ListConfigurationWorkspacesOptions())
+                ->setComponentId('keboola.runner-config-test')
+                ->setConfigurationId($configurationId)
+        );
+        self::assertCount(1, $workspaces);
+        // cleanup after the test
+        $workspacesApi = new Workspaces($this->client);
+        $workspacesApi->deleteWorkspace($workspaces[0]['id']);
+        self::assertTrue($logger->hasInfoThatContains('Created a new persistent workspace'));
+    }
+
+    public function testAbsWorkspaceConfigOneWorkspace()
+    {
+        $component = new Component([
+            'id' => 'keboola.runner-config-test',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'keboola/docker-demo',
+                    'tag' => 'master'
+                ],
+                'staging-storage' => [
+                    'input' => 'workspace-abs',
+                    'output' => 'workspace-abs',
+                ],
+            ],
+        ]);
+        $client = self::getMockBuilder(Client::class)
+            ->setConstructorArgs([[
+                'url' => STORAGE_API_URL_SYNAPSE,
+                'token' => STORAGE_API_TOKEN_SYNAPSE,
+            ]])
+            ->setMethods(['apiDelete'])
+            ->getMock();
+        $client->expects(self::never())->method('apiDelete');
+        /** @var Client $client */
+        $configuration = new Configuration();
+        $configuration->setConfiguration([]);
+        $configuration->setName('test-dataloader');
+        $configuration->setComponentId('keboola.runner-config-test');
+        $componentsApi = new Components($this->client);
+        $configurationId = $componentsApi->addConfiguration($configuration)['id'];
+        $workspace = $componentsApi->createConfigurationWorkspace(
+            'keboola.runner-config-test',
+            $configurationId,
+            ['backend' => 'abs']
+        );
+        $clientWrapper = new ClientWrapper($client, null, null, '');
+        $logger = new TestLogger();
+        $dataLoader = new DataLoader(
+            $clientWrapper,
+            $logger,
+            $this->workingDir->getDataDir(),
+            new JobDefinition([], $component, $configurationId),
+            new OutputFilter()
+        );
+
+        $dataLoader->storeOutput();
+
+        $credentials = $dataLoader->getWorkspaceCredentials();
+        self::assertEquals(['connectionString', 'container'], array_keys($credentials));
+        self::assertStringStartsWith('BlobEndpoint=https://', $credentials['connectionString']);
+        $workspaces = $componentsApi->listConfigurationWorkspaces(
+            (new ListConfigurationWorkspacesOptions())
+                ->setComponentId('keboola.runner-config-test')
+                ->setConfigurationId($configurationId)
+        );
+        self::assertCount(1, $workspaces);
+        $dataLoader->cleanWorkspace();
+        // double check that workspace still exists
+        $workspaces = $componentsApi->listConfigurationWorkspaces(
+            (new ListConfigurationWorkspacesOptions())
+                ->setComponentId('keboola.runner-config-test')
+                ->setConfigurationId($configurationId)
+        );
+        self::assertCount(1, $workspaces);
+        // and it must be the same workspace we created beforehand
+        self::assertEquals($workspace['id'], $workspaces[0]['id']);
+        // cleanup after the test
+        $workspacesApi = new Workspaces($this->client);
+        $workspacesApi->deleteWorkspace($workspaces[0]['id']);
+        self::assertTrue($logger->hasInfoThatContains(
+            sprintf('Reusing persistent workspace "%s".', $workspace['id'])
+        ));
+    }
+
+    public function testAbsWorkspaceConfigMultipleWorkspace()
+    {
+        $component = new Component([
+            'id' => 'keboola.runner-config-test',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'keboola/docker-demo',
+                    'tag' => 'master'
+                ],
+                'staging-storage' => [
+                    'input' => 'workspace-abs',
+                    'output' => 'workspace-abs',
+                ],
+            ],
+        ]);
+        $client = self::getMockBuilder(Client::class)
+            ->setConstructorArgs([[
+                'url' => STORAGE_API_URL_SYNAPSE,
+                'token' => STORAGE_API_TOKEN_SYNAPSE,
+            ]])
+            ->setMethods(['apiDelete'])
+            ->getMock();
+        $client->expects(self::never())->method('apiDelete');
+        /** @var Client $client */
+        $configuration = new Configuration();
+        $configuration->setConfiguration([]);
+        $configuration->setName('test-dataloader');
+        $configuration->setComponentId('keboola.runner-config-test');
+        $componentsApi = new Components($this->client);
+        $configurationId = $componentsApi->addConfiguration($configuration)['id'];
+        $workspace1 = $componentsApi->createConfigurationWorkspace(
+            'keboola.runner-config-test',
+            $configurationId,
+            ['backend' => 'abs']
+        );
+        $workspace2 = $componentsApi->createConfigurationWorkspace(
+            'keboola.runner-config-test',
+            $configurationId,
+            ['backend' => 'abs']
+        );
+
+        $clientWrapper = new ClientWrapper($client, null, null, '');
+        $logger = new TestLogger();
+        try {
+            new DataLoader(
+                $clientWrapper,
+                $logger,
+                $this->workingDir->getDataDir(),
+                new JobDefinition([], $component, $configurationId),
+                new OutputFilter()
+            );
+        } catch (ApplicationException $e) {
+            self::assertEquals(
+                sprintf(
+                    'Multiple workspaces (total 2) found (IDs: %s, %s) for configuration "%s" of component "%s".',
+                        $workspace1['id'],
+                        $workspace2['id'],
+                        $configurationId,
+                        'keboola.runner-config-test'
+                ),
+                $e->getMessage()
+            );
+            $workspacesApi = new Workspaces($this->client);
+            $workspacesApi->deleteWorkspace($workspace1['id']);
+            $workspacesApi->deleteWorkspace($workspace2['id']);
+        }
+    }
+}

--- a/Tests/Runner/DataLoaderPersistentABSWorkspaceTest.php
+++ b/Tests/Runner/DataLoaderPersistentABSWorkspaceTest.php
@@ -279,10 +279,10 @@ class DataLoaderPersistentABSWorkspaceTest extends BaseDataLoaderTest
             self::assertEquals(
                 sprintf(
                     'Multiple workspaces (total 2) found (IDs: %s, %s) for configuration "%s" of component "%s".',
-                        $workspace1['id'],
-                        $workspace2['id'],
-                        $configurationId,
-                        'keboola.runner-config-test'
+                    $workspace1['id'],
+                    $workspace2['id'],
+                    $configurationId,
+                    'keboola.runner-config-test'
                 ),
                 $e->getMessage()
             );

--- a/Tests/backend-specific-tests/ABS/DataLoaderPersistentABSWorkspaceTest.php
+++ b/Tests/backend-specific-tests/ABS/DataLoaderPersistentABSWorkspaceTest.php
@@ -6,6 +6,7 @@ use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Docker\JobDefinition;
 use Keboola\DockerBundle\Docker\OutputFilter\OutputFilter;
 use Keboola\DockerBundle\Docker\Runner\DataLoader\DataLoader;
+use Keboola\DockerBundle\Docker\Runner\DataLoader\WorkspaceProviderFactoryFactory;
 use Keboola\DockerBundle\Docker\Runner\WorkingDirectory;
 use Keboola\DockerBundle\Exception\ApplicationException;
 use Keboola\DockerBundle\Tests\BaseDataLoaderTest;
@@ -268,12 +269,14 @@ class DataLoaderPersistentABSWorkspaceTest extends BaseDataLoaderTest
         $clientWrapper = new ClientWrapper($client, null, null, '');
         $logger = new TestLogger();
         try {
-            new DataLoader(
-                $clientWrapper,
+            $workspaceFactory = new WorkspaceProviderFactoryFactory(
                 $logger,
-                $this->workingDir->getDataDir(),
-                new JobDefinition([], $component, $configurationId),
-                new OutputFilter()
+                $clientWrapper
+            );
+            $workspaceFactory->getWorkspaceProviderFactory(
+                'workspace-abs',
+                $component,
+                $configurationId
             );
         } catch (ApplicationException $e) {
             self::assertEquals(

--- a/Tests/backend-specific-tests/Synapse/RunnerSynapseTest.php
+++ b/Tests/backend-specific-tests/Synapse/RunnerSynapseTest.php
@@ -33,6 +33,10 @@ class RunnerSynapseTest extends BaseRunnerTest
                 }
             }
         }
+    }
+
+    private function clearConfigs()
+    {
         $componentsApi = new Components($this->client);
         $configurations = $componentsApi->listComponentConfigurations(
             (new ListComponentConfigurationsOptions())->setComponentId('keboola.runner-workspace-synapse-test')
@@ -103,6 +107,7 @@ class RunnerSynapseTest extends BaseRunnerTest
     {
         $this->clearBuckets();
         $this->createBuckets();
+        $this->clearConfigs();
         $temp = new Temp();
         $temp->initRunFolder();
         $csv = new CsvFile($temp->getTmpFolder() . '/upload.csv');
@@ -184,6 +189,7 @@ class RunnerSynapseTest extends BaseRunnerTest
     public function testAbsWorkspaceMapping()
     {
         $this->clearFiles();
+        $this->clearConfigs();
         $temp = new Temp();
         $temp->initRunFolder();
         file_put_contents($temp->getTmpFolder() . '/my-lovely-file.wtf', 'some data');
@@ -258,6 +264,7 @@ class RunnerSynapseTest extends BaseRunnerTest
     {
         $this->clearFiles();
         $this->clearBuckets();
+        $this->clearConfigs();
         $this->createBuckets();
         $temp = new Temp();
         $temp->initRunFolder();
@@ -348,6 +355,7 @@ class RunnerSynapseTest extends BaseRunnerTest
     public function testAbsWorkspaceMappingOutput()
     {
         $this->clearBuckets();
+        $this->clearConfigs();
         $componentData = [
             'id' => 'keboola.runner-workspace-abs-test',
             'data' => [

--- a/Tests/backend-specific-tests/Synapse/RunnerSynapseTest.php
+++ b/Tests/backend-specific-tests/Synapse/RunnerSynapseTest.php
@@ -11,9 +11,11 @@ use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Options\Components\Configuration;
+use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Keboola\StorageApi\Options\Components\ListConfigurationWorkspacesOptions;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
+use Keboola\StorageApi\Workspaces;
 use Keboola\Temp\Temp;
 
 class RunnerSynapseTest extends BaseRunnerTest
@@ -30,6 +32,22 @@ class RunnerSynapseTest extends BaseRunnerTest
                     throw $e;
                 }
             }
+        }
+        $componentsApi = new Components($this->client);
+        $configurations = $componentsApi->listComponentConfigurations(
+            (new ListComponentConfigurationsOptions())->setComponentId('keboola.runner-workspace-synapse-test')
+        );
+        $workspacesApi = new Workspaces($this->client);
+        foreach ($configurations as $configuration) {
+            $workspaces = $componentsApi->listConfigurationWorkspaces(
+                (new ListConfigurationWorkspacesOptions())
+                    ->setComponentId('keboola.runner-workspace-synapse-test')
+                    ->setConfigurationId($configuration['id'])
+            );
+            foreach ($workspaces as $workspace) {
+                $workspacesApi->deleteWorkspace($workspace['id']);
+            }
+            $componentsApi->deleteConfiguration('keboola.runner-workspace-synapse-test', $configuration['id']);
         }
     }
 
@@ -161,7 +179,6 @@ class RunnerSynapseTest extends BaseRunnerTest
         $options->setConfigurationId($configId);
         self::assertCount(0, $components->listConfigurationWorkspaces($options));
         self::assertTrue($this->client->tableExists('out.c-synapse-runner-test.new-table'));
-        $components->deleteConfiguration('keboola.runner-workspace-synapse-test', $configId);
     }
 
     public function testAbsWorkspaceMapping()
@@ -230,11 +247,11 @@ class RunnerSynapseTest extends BaseRunnerTest
         );
         self::assertTrue($this->getContainerHandler()->hasInfoThatContains(sprintf('data/in/files/my_lovely_file.wtf/%s', $fileId)));
 
-        // assert the workspace is removed
+        // assert the workspace is preserved
         $options = new ListConfigurationWorkspacesOptions();
         $options->setComponentId('keboola.runner-workspace-abs-test');
         $options->setConfigurationId($configId);
-        self::assertCount(0, $components->listConfigurationWorkspaces($options));
+        self::assertCount(1, $components->listConfigurationWorkspaces($options));
     }
 
     public function testAbsWorkspaceMappingCombined()
@@ -321,11 +338,11 @@ class RunnerSynapseTest extends BaseRunnerTest
             sprintf('data/in/files/my_lovely_file.wtf/%s', $fileId)
         ));
         self::assertTrue($this->getContainerHandler()->hasInfoThatContains('data/in/tables/mytable3.csvmanifest'));
-        // assert the workspace is removed
+        // assert the workspace is preserved
         $options = new ListConfigurationWorkspacesOptions();
         $options->setComponentId('keboola.runner-workspace-abs-test');
         $options->setConfigurationId($configId);
-        self::assertCount(0, $components->listConfigurationWorkspaces($options));
+        self::assertCount(1, $components->listConfigurationWorkspaces($options));
     }
 
     public function testAbsWorkspaceMappingOutput()
@@ -391,6 +408,6 @@ class RunnerSynapseTest extends BaseRunnerTest
         $options = new ListConfigurationWorkspacesOptions();
         $options->setComponentId('keboola.runner-workspace-abs-test');
         $options->setConfigurationId($configId);
-        self::assertCount(0, $components->listConfigurationWorkspaces($options));
+        self::assertCount(1, $components->listConfigurationWorkspaces($options));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "keboola/object-encryptor": "^0.3",
         "keboola/output-mapping": "^14.0",
         "keboola/php-utils": "^2.0",
-        "keboola/staging-provider": "dev-odin-PS-2159 as 1.0.0",
+        "keboola/staging-provider": "^1.1",
         "keboola/storage-api-php-client-branch-wrapper": "^1.0.0",
         "keboola/syrup": "^11.3",
         "mustache/mustache": "^2.13",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "keboola/object-encryptor": "^0.3",
         "keboola/output-mapping": "^14.0",
         "keboola/php-utils": "^2.0",
-        "keboola/staging-provider": "^1.0",
+        "keboola/staging-provider": "dev-odin-PS-2159 as 1.0.0",
         "keboola/storage-api-php-client-branch-wrapper": "^1.0.0",
         "keboola/syrup": "^11.3",
         "mustache/mustache": "^2.13",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.180.5",
+            "version": "3.180.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "948a4defbe2a571cc4460725015b8e98b7060f2d"
+                "reference": "1a836be14ba664ea11eb965dec77715e9e607013"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/948a4defbe2a571cc4460725015b8e98b7060f2d",
-                "reference": "948a4defbe2a571cc4460725015b8e98b7060f2d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1a836be14ba664ea11eb965dec77715e9e607013",
+                "reference": "1a836be14ba664ea11eb965dec77715e9e607013",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2021-05-07T18:12:43+00:00"
+            "time": "2021-05-10T18:17:07+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -1891,16 +1891,16 @@
         },
         {
             "name": "keboola/input-mapping",
-            "version": "12.6.1",
+            "version": "12.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "2db6e1c73ee69d64ed82e5ff69f96d285a5f199e"
+                "reference": "27ef8aba7ea71199909a421e3d609b6f838c3673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/2db6e1c73ee69d64ed82e5ff69f96d285a5f199e",
-                "reference": "2db6e1c73ee69d64ed82e5ff69f96d285a5f199e",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/27ef8aba7ea71199909a421e3d609b6f838c3673",
+                "reference": "27ef8aba7ea71199909a421e3d609b6f838c3673",
                 "shasum": ""
             },
             "require": {
@@ -1934,7 +1934,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI input mapping and exporting to files",
-            "time": "2021-05-07T16:18:26+00:00"
+            "time": "2021-05-10T19:03:08+00:00"
         },
         {
             "name": "keboola/oauth-v2-php-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4232fb6dac5917aff02de62f516582b",
+    "content-hash": "248cdf72ff852f497f80addf90984438",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.180.6",
+            "version": "3.180.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "1a836be14ba664ea11eb965dec77715e9e607013"
+                "reference": "3e377fdfd0cda4e1412ac7aca93814d4f032d236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1a836be14ba664ea11eb965dec77715e9e607013",
-                "reference": "1a836be14ba664ea11eb965dec77715e9e607013",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3e377fdfd0cda4e1412ac7aca93814d4f032d236",
+                "reference": "3e377fdfd0cda4e1412ac7aca93814d4f032d236",
                 "shasum": ""
             },
             "require": {
@@ -89,12 +89,7 @@
                 "s3",
                 "sdk"
             ],
-            "support": {
-                "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
-                "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.180.6"
-            },
-            "time": "2021-05-10T18:17:07+00:00"
+            "time": "2021-05-06T18:13:26+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -151,11 +146,6 @@
                 "ssl",
                 "tls"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.9"
-            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -232,10 +222,6 @@
                 "security",
                 "symmetric key cryptography"
             ],
-            "support": {
-                "issues": "https://github.com/defuse/php-encryption/issues",
-                "source": "https://github.com/defuse/php-encryption/tree/v2.3.1"
-            },
             "time": "2021-04-09T23:57:26+00:00"
         },
         {
@@ -304,10 +290,6 @@
                 "docblock",
                 "parser"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/v1.4.0"
-            },
             "time": "2017-02-24T16:22:25+00:00"
         },
         {
@@ -378,10 +360,6 @@
                 "cache",
                 "caching"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/1.6.x"
-            },
             "time": "2017-07-22T12:49:21+00:00"
         },
         {
@@ -449,10 +427,6 @@
                 "collections",
                 "iterator"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/master"
-            },
             "time": "2017-01-03T10:49:41+00:00"
         },
         {
@@ -526,10 +500,6 @@
                 "persistence",
                 "spl"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/v2.7.3"
-            },
             "time": "2017-07-22T08:35:12+00:00"
         },
         {
@@ -601,10 +571,6 @@
                 "persistence",
                 "queryobject"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/v2.5.13"
-            },
             "time": "2017-07-22T20:44:48+00:00"
         },
         {
@@ -690,10 +656,6 @@
                 "orm",
                 "persistence"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/DoctrineBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineBundle/tree/1.10.x"
-            },
             "time": "2019-04-04T08:03:53+00:00"
         },
         {
@@ -785,10 +747,6 @@
                 "cache",
                 "caching"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/DoctrineCacheBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineCacheBundle/tree/1.3"
-            },
             "abandoned": true,
             "time": "2018-11-09T06:25:35+00:00"
         },
@@ -851,10 +809,6 @@
                 "migrations",
                 "schema"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/DoctrineMigrationsBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineMigrationsBundle/tree/1.3"
-            },
             "time": "2018-12-03T11:55:33+00:00"
         },
         {
@@ -922,9 +876,6 @@
                 "singularize",
                 "string"
             ],
-            "support": {
-                "source": "https://github.com/doctrine/inflector/tree/master"
-            },
             "time": "2015-11-06T14:35:42+00:00"
         },
         {
@@ -979,10 +930,6 @@
                 "constructor",
                 "instantiate"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/master"
-            },
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
@@ -1043,10 +990,6 @@
                 "parser",
                 "php"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.0.2"
-            },
             "time": "2019-06-08T11:03:04+00:00"
         },
         {
@@ -1121,10 +1064,6 @@
                 "database",
                 "migrations"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/master"
-            },
             "time": "2016-12-25T22:54:00+00:00"
         },
         {
@@ -1201,10 +1140,6 @@
                 "database",
                 "orm"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/v2.5.14"
-            },
             "time": "2017-12-17T02:57:51+00:00"
         },
         {
@@ -1260,10 +1195,6 @@
                 "elasticsearch",
                 "search"
             ],
-            "support": {
-                "issues": "https://github.com/elastic/elasticsearch-php/issues",
-                "source": "https://github.com/elastic/elasticsearch-php/tree/v1.4.1"
-            },
             "time": "2015-09-17T22:01:44+00:00"
         },
         {
@@ -1312,10 +1243,6 @@
                 "event-dispatcher",
                 "event-emitter"
             ],
-            "support": {
-                "issues": "https://github.com/igorw/evenement/issues",
-                "source": "https://github.com/igorw/evenement/tree/master"
-            },
             "time": "2017-07-17T17:39:19+00:00"
         },
         {
@@ -1370,10 +1297,6 @@
                 }
             ],
             "description": "A php implementation to send log-messages to a GELF compatible backend like Graylog2.",
-            "support": {
-                "issues": "https://github.com/bzikarsky/gelf-php/issues",
-                "source": "https://github.com/bzikarsky/gelf-php/tree/1.7.0"
-            },
             "time": "2021-02-04T09:05:55+00:00"
         },
         {
@@ -1469,10 +1392,6 @@
                 "rest",
                 "web service"
             ],
-            "support": {
-                "issues": "https://github.com/guzzle/guzzle3/issues",
-                "source": "https://github.com/guzzle/guzzle3/tree/master"
-            },
             "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18T18:23:50+00:00"
         },
@@ -1541,10 +1460,6 @@
                 "rest",
                 "web service"
             ],
-            "support": {
-                "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5"
-            },
             "time": "2020-06-16T21:01:06+00:00"
         },
         {
@@ -1596,10 +1511,6 @@
             "keywords": [
                 "promise"
             ],
-            "support": {
-                "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.4.1"
-            },
             "time": "2021-03-07T09:25:29+00:00"
         },
         {
@@ -1671,10 +1582,6 @@
                 "uri",
                 "url"
             ],
-            "support": {
-                "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
-            },
             "time": "2021-04-26T09:17:50+00:00"
         },
         {
@@ -1717,10 +1624,6 @@
                 "hashing",
                 "password"
             ],
-            "support": {
-                "issues": "https://github.com/ircmaxell/password_compat/issues",
-                "source": "https://github.com/ircmaxell/password_compat/tree/v1.0"
-            },
             "time": "2014-11-20T16:49:30+00:00"
         },
         {
@@ -1771,10 +1674,6 @@
                 "highlight",
                 "sql"
             ],
-            "support": {
-                "issues": "https://github.com/jdorn/sql-formatter/issues",
-                "source": "https://github.com/jdorn/sql-formatter/tree/master"
-            },
             "time": "2014-01-12T16:20:24+00:00"
         },
         {
@@ -1815,10 +1714,6 @@
             "keywords": [
                 "deprecated"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/legacy-php-encryption/issues",
-                "source": "https://github.com/keboola/legacy-php-encryption/tree/master"
-            },
             "time": "2018-08-09T09:06:17+00:00"
         },
         {
@@ -1870,10 +1765,6 @@
                 "keboola",
                 "key vault"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/azure-key-vault-php-client/issues",
-                "source": "https://github.com/keboola/azure-key-vault-php-client/tree/1.1.0"
-            },
             "time": "2020-11-02T23:14:05+00:00"
         },
         {
@@ -1905,10 +1796,6 @@
             ],
             "description": "Keboola CSV reader and writer",
             "homepage": "http://keboola.com",
-            "support": {
-                "issues": "https://github.com/keboola/php-csv/issues",
-                "source": "https://github.com/keboola/php-csv/tree/master"
-            },
             "time": "2016-04-21T20:46:22+00:00"
         },
         {
@@ -1955,10 +1842,6 @@
                 "s3",
                 "uploader"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/debug-log-uploader/issues",
-                "source": "https://github.com/keboola/debug-log-uploader/tree/master"
-            },
             "time": "2017-01-16T17:55:10+00:00"
         },
         {
@@ -2004,23 +1887,20 @@
                 }
             ],
             "description": "Simple PHP server for GELF logger",
-            "support": {
-                "source": "https://github.com/keboola/gelf-server/tree/2.0.1"
-            },
             "time": "2020-01-30T09:14:19+00:00"
         },
         {
             "name": "keboola/input-mapping",
-            "version": "12.7.0",
+            "version": "12.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/input-mapping.git",
-                "reference": "27ef8aba7ea71199909a421e3d609b6f838c3673"
+                "reference": "2db6e1c73ee69d64ed82e5ff69f96d285a5f199e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/27ef8aba7ea71199909a421e3d609b6f838c3673",
-                "reference": "27ef8aba7ea71199909a421e3d609b6f838c3673",
+                "url": "https://api.github.com/repos/keboola/input-mapping/zipball/2db6e1c73ee69d64ed82e5ff69f96d285a5f199e",
+                "reference": "2db6e1c73ee69d64ed82e5ff69f96d285a5f199e",
                 "shasum": ""
             },
             "require": {
@@ -2054,11 +1934,7 @@
                 }
             ],
             "description": "Shared component for processing SAPI input mapping and exporting to files",
-            "support": {
-                "issues": "https://github.com/keboola/input-mapping/issues",
-                "source": "https://github.com/keboola/input-mapping/tree/12.7.0"
-            },
-            "time": "2021-05-10T19:03:08+00:00"
+            "time": "2021-05-07T16:18:26+00:00"
         },
         {
             "name": "keboola/oauth-v2-php-client",
@@ -2097,10 +1973,6 @@
                 }
             ],
             "description": "Keboola OAuth v2 API Client",
-            "support": {
-                "issues": "https://github.com/keboola/oauth-v2-php-client/issues",
-                "source": "https://github.com/keboola/oauth-v2-php-client/tree/master"
-            },
             "time": "2019-11-06T14:08:03+00:00"
         },
         {
@@ -2155,9 +2027,6 @@
                 "encryption",
                 "json"
             ],
-            "support": {
-                "source": "https://github.com/keboola/object-encryptor/tree/0.3.1"
-            },
             "time": "2020-07-31T08:34:05+00:00"
         },
         {
@@ -2210,10 +2079,6 @@
                 }
             ],
             "description": "Shared component for processing SAPI output mapping and importing data to KBC",
-            "support": {
-                "issues": "https://github.com/keboola/output-mapping/issues",
-                "source": "https://github.com/keboola/output-mapping/tree/14.5.1"
-            },
             "time": "2021-05-04T08:56:46+00:00"
         },
         {
@@ -2260,10 +2125,6 @@
                 "mcrypt",
                 "security"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/php-encryption/issues",
-                "source": "https://github.com/keboola/php-encryption/tree/Branch_0.2.3"
-            },
             "abandoned": "defuse/php-encryption",
             "time": "2018-08-09T08:26:20+00:00"
         },
@@ -2314,10 +2175,6 @@
                 "filesystem",
                 "temp"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/php-temp/issues",
-                "source": "https://github.com/keboola/php-temp/tree/1.0.0"
-            },
             "time": "2017-11-13T13:02:19+00:00"
         },
         {
@@ -2384,10 +2241,6 @@
             "keywords": [
                 "utility"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/php-utils/issues",
-                "source": "https://github.com/keboola/php-utils/tree/master"
-            },
             "time": "2018-04-11T14:40:53+00:00"
         },
         {
@@ -2429,24 +2282,20 @@
                 }
             ],
             "description": "Column name sanitizer",
-            "support": {
-                "issues": "https://github.com/keboola/sanitizer/issues",
-                "source": "https://github.com/keboola/sanitizer/tree/0.1.0"
-            },
             "time": "2019-01-11T10:21:17+00:00"
         },
         {
             "name": "keboola/staging-provider",
-            "version": "1.1.0",
+            "version": "dev-odin-PS-2159",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/staging-provider.git",
-                "reference": "97b1ecc1773488176e9b811d466ac252e14223fd"
+                "reference": "d3b3b82cfc83335f9bbc5b7ba517cc18fbe4a8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/staging-provider/zipball/97b1ecc1773488176e9b811d466ac252e14223fd",
-                "reference": "97b1ecc1773488176e9b811d466ac252e14223fd",
+                "url": "https://api.github.com/repos/keboola/staging-provider/zipball/d3b3b82cfc83335f9bbc5b7ba517cc18fbe4a8f4",
+                "reference": "d3b3b82cfc83335f9bbc5b7ba517cc18fbe4a8f4",
                 "shasum": ""
             },
             "require": {
@@ -2479,10 +2328,7 @@
                 "keboola",
                 "staging-provider"
             ],
-            "support": {
-                "source": "https://github.com/keboola/staging-provider/tree/1.1.0"
-            },
-            "time": "2021-05-10T15:17:21+00:00"
+            "time": "2021-05-07T15:12:26+00:00"
         },
         {
             "name": "keboola/storage-api-client",
@@ -2534,10 +2380,6 @@
             ],
             "description": "Keboola Storage API PHP CLient",
             "homepage": "http://keboola.com",
-            "support": {
-                "issues": "https://github.com/keboola/storage-api-php-client/issues",
-                "source": "https://github.com/keboola/storage-api-php-client/tree/11.7.0"
-            },
             "time": "2021-02-05T20:11:13+00:00"
         },
         {
@@ -2586,10 +2428,6 @@
                 "keboola",
                 "storage api"
             ],
-            "support": {
-                "issues": "https://github.com/keboola/storage-api-php-client-branch-wrapper/issues",
-                "source": "https://github.com/keboola/storage-api-php-client-branch-wrapper/tree/1.0.1"
-            },
             "time": "2021-03-25T14:45:25+00:00"
         },
         {
@@ -2658,10 +2496,6 @@
                 }
             ],
             "description": "Syrup",
-            "support": {
-                "issues": "https://github.com/keboola/syrup/issues",
-                "source": "https://github.com/keboola/syrup/tree/11.6.0"
-            },
             "time": "2021-04-13T11:11:43+00:00"
         },
         {
@@ -2739,10 +2573,6 @@
                 "compression",
                 "minification"
             ],
-            "support": {
-                "issues": "https://github.com/kriswallsmith/assetic/issues",
-                "source": "https://github.com/kriswallsmith/assetic/tree/master"
-            },
             "time": "2016-11-11T18:43:20+00:00"
         },
         {
@@ -2787,10 +2617,6 @@
                 "sdk",
                 "storage"
             ],
-            "support": {
-                "issues": "https://github.com/Azure/azure-storage-blob-php/issues",
-                "source": "https://github.com/Azure/azure-storage-blob-php/tree/v1.5.2"
-            },
             "time": "2020-12-29T02:22:11+00:00"
         },
         {
@@ -2835,10 +2661,6 @@
                 "sdk",
                 "storage"
             ],
-            "support": {
-                "issues": "https://github.com/Azure/azure-storage-common-php/issues",
-                "source": "https://github.com/Azure/azure-storage-common-php/tree/v1.5.1"
-            },
             "time": "2020-12-28T07:59:51+00:00"
         },
         {
@@ -2911,10 +2733,6 @@
                 "logging",
                 "psr-3"
             ],
-            "support": {
-                "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/1.26.0"
-            },
             "funding": [
                 {
                     "url": "https://github.com/Seldaek",
@@ -2982,10 +2800,6 @@
                 "json",
                 "jsonpath"
             ],
-            "support": {
-                "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.6.0"
-            },
             "time": "2020-07-31T21:01:56+00:00"
         },
         {
@@ -3032,10 +2846,6 @@
                 "mustache",
                 "templating"
             ],
-            "support": {
-                "issues": "https://github.com/bobthecow/mustache.php/issues",
-                "source": "https://github.com/bobthecow/mustache.php/tree/master"
-            },
             "time": "2019-11-23T21:40:31+00:00"
         },
         {
@@ -3099,10 +2909,6 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "support": {
-                "issues": "https://github.com/Ocramius/ProxyManager/issues",
-                "source": "https://github.com/Ocramius/ProxyManager/tree/1.0.x"
-            },
             "time": "2015-08-09T04:28:19+00:00"
         },
         {
@@ -3166,11 +2972,6 @@
                 "hex2bin",
                 "rfc4648"
             ],
-            "support": {
-                "email": "info@paragonie.com",
-                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
-                "source": "https://github.com/paragonie/constant_time_encoding"
-            },
             "time": "2018-04-30T17:57:16+00:00"
         },
         {
@@ -3220,11 +3021,6 @@
                 "pseudorandom",
                 "random"
             ],
-            "support": {
-                "email": "info@paragonie.com",
-                "issues": "https://github.com/paragonie/random_compat/issues",
-                "source": "https://github.com/paragonie/random_compat"
-            },
             "time": "2021-04-17T09:33:01+00:00"
         },
         {
@@ -3277,11 +3073,6 @@
                 "encryption",
                 "mcrypt"
             ],
-            "support": {
-                "email": "terrafrost@php.net",
-                "issues": "https://github.com/phpseclib/mcrypt_compat/issues",
-                "source": "https://github.com/phpseclib/mcrypt_compat"
-            },
             "time": "2019-05-26T13:54:43+00:00"
         },
         {
@@ -3373,10 +3164,6 @@
                 "x.509",
                 "x509"
             ],
-            "support": {
-                "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.31"
-            },
             "funding": [
                 {
                     "url": "https://github.com/terrafrost",
@@ -3441,10 +3228,6 @@
                 "container",
                 "dependency injection"
             ],
-            "support": {
-                "issues": "https://github.com/silexphp/Pimple/issues",
-                "source": "https://github.com/silexphp/Pimple/tree/master"
-            },
             "time": "2018-01-21T07:42:36+00:00"
         },
         {
@@ -3494,10 +3277,6 @@
                 "container-interop",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
-            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -3548,9 +3327,6 @@
                 "request",
                 "response"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
-            },
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
@@ -3598,9 +3374,6 @@
                 "psr",
                 "psr-3"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
             "time": "2021-05-03T11:20:27+00:00"
         },
         {
@@ -3641,10 +3414,6 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
@@ -3707,10 +3476,6 @@
                 "promise",
                 "reactphp"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/cache/issues",
-                "source": "https://github.com/reactphp/cache/tree/v1.1.1"
-            },
             "funding": [
                 {
                     "url": "https://github.com/WyriHaximus",
@@ -3776,10 +3541,6 @@
                 "server",
                 "udp"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/datagram/issues",
-                "source": "https://github.com/reactphp/datagram/tree/v1.5.0"
-            },
             "time": "2019-07-10T10:04:15+00:00"
         },
         {
@@ -3825,10 +3586,6 @@
                 "dns-resolver",
                 "reactphp"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/dns/issues",
-                "source": "https://github.com/reactphp/dns/tree/v0.4.19"
-            },
             "time": "2019-07-10T21:00:53+00:00"
         },
         {
@@ -3871,10 +3628,6 @@
                 "asynchronous",
                 "event-loop"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.1.1"
-            },
             "time": "2020-01-01T18:39:52+00:00"
         },
         {
@@ -3921,10 +3674,6 @@
                 "promise",
                 "promises"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.8.0"
-            },
             "time": "2020-05-12T15:16:56+00:00"
         },
         {
@@ -3978,10 +3727,6 @@
                 "timeout",
                 "timer"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise-timer/issues",
-                "source": "https://github.com/reactphp/promise-timer/tree/v1.6.0"
-            },
             "time": "2020-07-10T12:18:06+00:00"
         },
         {
@@ -4029,10 +3774,6 @@
                 "reactphp",
                 "stream"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/socket/issues",
-                "source": "https://github.com/reactphp/socket/tree/v0.8.12"
-            },
             "time": "2018-06-11T14:33:43+00:00"
         },
         {
@@ -4079,10 +3820,6 @@
                 "stream",
                 "writable"
             ],
-            "support": {
-                "issues": "https://github.com/reactphp/stream/issues",
-                "source": "https://github.com/reactphp/stream/tree/v1.1.1"
-            },
             "time": "2020-05-04T10:17:57+00:00"
         },
         {
@@ -4132,10 +3869,6 @@
                 "parser",
                 "validator"
             ],
-            "support": {
-                "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/Seldaek",
@@ -4206,10 +3939,6 @@
                 "configuration",
                 "distribution"
             ],
-            "support": {
-                "issues": "https://github.com/sensiolabs/SensioDistributionBundle/issues",
-                "source": "https://github.com/sensiolabs/SensioDistributionBundle/tree/4.0"
-            },
             "abandoned": true,
             "time": "2019-06-18T15:41:34+00:00"
         },
@@ -4281,10 +4010,6 @@
                 "annotations",
                 "controllers"
             ],
-            "support": {
-                "issues": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues",
-                "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/3.0"
-            },
             "time": "2017-12-14T19:03:23+00:00"
         },
         {
@@ -4333,10 +4058,6 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "support": {
-                "issues": "https://github.com/sensiolabs/SensioGeneratorBundle/issues",
-                "source": "https://github.com/sensiolabs/SensioGeneratorBundle/tree/master"
-            },
             "abandoned": "symfony/maker-bundle",
             "time": "2015-03-17T06:36:52+00:00"
         },
@@ -4384,10 +4105,6 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "support": {
-                "issues": "https://github.com/sensiolabs/security-checker/issues",
-                "source": "https://github.com/sensiolabs/security-checker/tree/master"
-            },
             "abandoned": "https://github.com/fabpot/local-php-security-checker",
             "time": "2018-12-19T17:14:59+00:00"
         },
@@ -4443,10 +4160,6 @@
                 "mail",
                 "mailer"
             ],
-            "support": {
-                "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-                "source": "https://github.com/swiftmailer/swiftmailer/tree/v5.4.12"
-            },
             "time": "2018-07-31T09:26:32+00:00"
         },
         {
@@ -4517,10 +4230,6 @@
                 "compression",
                 "minification"
             ],
-            "support": {
-                "issues": "https://github.com/symfony/assetic-bundle/issues",
-                "source": "https://github.com/symfony/assetic-bundle/tree/master"
-            },
             "abandoned": "symfony/webpack-encore-pack",
             "time": "2017-07-14T07:26:46+00:00"
         },
@@ -4582,10 +4291,6 @@
                 "log",
                 "logging"
             ],
-            "support": {
-                "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/2.x"
-            },
             "time": "2017-01-02T19:04:26+00:00"
         },
         {
@@ -4646,9 +4351,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-apcu/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4725,9 +4427,6 @@
                 "polyfill",
                 "portable"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4804,9 +4503,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4892,9 +4588,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4976,9 +4669,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5056,9 +4746,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5135,9 +4822,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php54/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5212,9 +4896,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php55/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5289,9 +4970,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php56/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5369,9 +5047,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php70/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5445,9 +5120,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5518,9 +5190,6 @@
                 "polyfill",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-util/tree/v1.19.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -5596,10 +5265,6 @@
             ],
             "description": "Symfony Security Component - ACL (Access Control List)",
             "homepage": "https://symfony.com",
-            "support": {
-                "issues": "https://github.com/symfony/security-acl/issues",
-                "source": "https://github.com/symfony/security-acl/tree/master"
-            },
             "time": "2019-12-12T09:55:57+00:00"
         },
         {
@@ -5659,10 +5324,6 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "support": {
-                "issues": "https://github.com/symfony/swiftmailer-bundle/issues",
-                "source": "https://github.com/symfony/swiftmailer-bundle/tree/2.6"
-            },
             "time": "2017-10-19T01:06:41+00:00"
         },
         {
@@ -5803,10 +5464,6 @@
             "keywords": [
                 "framework"
             ],
-            "support": {
-                "issues": "https://github.com/symfony/symfony/issues",
-                "source": "https://github.com/symfony/symfony/tree/v2.8.52"
-            },
             "time": "2019-11-13T08:36:42+00:00"
         },
         {
@@ -5871,10 +5528,6 @@
             "keywords": [
                 "templating"
             ],
-            "support": {
-                "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/1.x"
-            },
             "time": "2020-02-11T05:59:23+00:00"
         },
         {
@@ -5922,10 +5575,6 @@
                 "repeat",
                 "retry"
             ],
-            "support": {
-                "issues": "https://github.com/vkartaviy/retry/issues",
-                "source": "https://github.com/vkartaviy/retry/tree/master"
-            },
             "time": "2015-05-06T17:39:09+00:00"
         },
         {
@@ -5978,10 +5627,6 @@
                 "code",
                 "zf2"
             ],
-            "support": {
-                "issues": "https://github.com/zendframework/zend-code/issues",
-                "source": "https://github.com/zendframework/zend-code/tree/release-2.6"
-            },
             "abandoned": "laminas/laminas-code",
             "time": "2016-04-20T17:26:42+00:00"
         },
@@ -6037,10 +5682,6 @@
                 "events",
                 "zf2"
             ],
-            "support": {
-                "issues": "https://github.com/zendframework/zend-eventmanager/issues",
-                "source": "https://github.com/zendframework/zend-eventmanager/tree/master"
-            },
             "abandoned": "laminas/laminas-eventmanager",
             "time": "2018-04-25T15:33:34+00:00"
         },
@@ -6092,14 +5733,6 @@
                 "json",
                 "zf"
             ],
-            "support": {
-                "chat": "https://zendframework-slack.herokuapp.com",
-                "docs": "https://docs.zendframework.com/zend-json/",
-                "forum": "https://discourse.zendframework.com/c/questions/components",
-                "issues": "https://github.com/zendframework/zend-json/issues",
-                "rss": "https://github.com/zendframework/zend-json/releases.atom",
-                "source": "https://github.com/zendframework/zend-json"
-            },
             "abandoned": "laminas/laminas-json",
             "time": "2019-10-09T13:56:13+00:00"
         }
@@ -6162,10 +5795,6 @@
                 "codeclimate",
                 "coverage"
             ],
-            "support": {
-                "issues": "https://github.com/codeclimate/php-test-reporter/issues",
-                "source": "https://github.com/codeclimate/php-test-reporter/tree/master"
-            },
             "time": "2017-02-15T22:25:47+00:00"
         },
         {
@@ -6211,10 +5840,6 @@
                 "object",
                 "object graph"
             ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
-            },
             "time": "2017-10-19T19:58:43+00:00"
         },
         {
@@ -6284,10 +5909,6 @@
                 "ssl",
                 "tls"
             ],
-            "support": {
-                "issues": "https://github.com/humbug/file_get_contents/issues",
-                "source": "https://github.com/humbug/file_get_contents/tree/master"
-            },
             "time": "2018-02-12T18:47:17+00:00"
         },
         {
@@ -6340,10 +5961,6 @@
                 "self-update",
                 "update"
             ],
-            "support": {
-                "issues": "https://github.com/humbug/phar-updater/issues",
-                "source": "https://github.com/humbug/phar-updater/tree/1.0"
-            },
             "abandoned": true,
             "time": "2018-03-30T12:52:15+00:00"
         },
@@ -6399,10 +6016,6 @@
                 "reflection",
                 "static analysis"
             ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
-            },
             "time": "2017-09-11T18:02:19+00:00"
         },
         {
@@ -6448,10 +6061,6 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/3.x"
-            },
             "time": "2017-11-10T14:09:06+00:00"
         },
         {
@@ -6499,10 +6108,6 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/master"
-            },
             "time": "2017-07-14T14:27:02+00:00"
         },
         {
@@ -6566,10 +6171,6 @@
                 "spy",
                 "stub"
             ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
-            },
             "time": "2020-03-05T15:02:03+00:00"
         },
         {
@@ -6633,11 +6234,6 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/4.0"
-            },
             "time": "2017-04-02T07:44:40+00:00"
         },
         {
@@ -6685,11 +6281,6 @@
                 "filesystem",
                 "iterator"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
-            },
             "time": "2017-11-27T13:52:08+00:00"
         },
         {
@@ -6731,10 +6322,6 @@
             "keywords": [
                 "template"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
-            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -6784,10 +6371,6 @@
             "keywords": [
                 "timer"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
-            },
             "time": "2017-02-26T11:10:40+00:00"
         },
         {
@@ -6837,10 +6420,6 @@
             "keywords": [
                 "tokenizer"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/1.4"
-            },
             "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
@@ -6924,10 +6503,6 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/5.7.27"
-            },
             "time": "2018-02-01T05:50:59+00:00"
         },
         {
@@ -6987,11 +6562,6 @@
                 "mock",
                 "xunit"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
-                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/3.4"
-            },
             "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
@@ -7054,10 +6624,6 @@
                 "github",
                 "test"
             ],
-            "support": {
-                "issues": "https://github.com/php-coveralls/php-coveralls/issues",
-                "source": "https://github.com/php-coveralls/php-coveralls/tree/v1.1.0"
-            },
             "abandoned": "php-coveralls/php-coveralls",
             "time": "2017-12-06T23:17:56+00:00"
         },
@@ -7104,10 +6670,6 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -7178,10 +6740,6 @@
                 "compare",
                 "equality"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
-            },
             "time": "2017-01-29T09:50:25+00:00"
         },
         {
@@ -7234,10 +6792,6 @@
             "keywords": [
                 "diff"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/1.4"
-            },
             "time": "2017-05-22T07:24:03+00:00"
         },
         {
@@ -7288,10 +6842,6 @@
                 "environment",
                 "hhvm"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/master"
-            },
             "time": "2016-11-26T07:53:53+00:00"
         },
         {
@@ -7359,10 +6909,6 @@
                 "export",
                 "exporter"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
-            },
             "time": "2016-11-19T08:54:04+00:00"
         },
         {
@@ -7414,10 +6960,6 @@
             "keywords": [
                 "global state"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/1.1.1"
-            },
             "time": "2015-10-12T03:26:01+00:00"
         },
         {
@@ -7464,10 +7006,6 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/master"
-            },
             "time": "2017-02-18T15:18:39+00:00"
         },
         {
@@ -7521,10 +7059,6 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
-            },
             "time": "2016-11-19T07:33:16+00:00"
         },
         {
@@ -7567,10 +7101,6 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
-            },
             "time": "2015-07-28T20:34:47+00:00"
         },
         {
@@ -7614,10 +7144,6 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/master"
-            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
@@ -7669,11 +7195,6 @@
                 "phpcs",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
             "time": "2021-04-09T00:54:41+00:00"
         },
         {
@@ -7723,16 +7244,21 @@
                 "check",
                 "validate"
             ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
-            },
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "1.0.0",
+            "alias_normalized": "1.0.0.0",
+            "version": "dev-odin-PS-2159",
+            "package": "keboola/staging-provider"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "keboola/staging-provider": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -7743,5 +7269,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "248cdf72ff852f497f80addf90984438",
+    "content-hash": "3728e7ecb6a622dcbb572641c12e73db",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.180.4",
+            "version": "3.180.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "3e377fdfd0cda4e1412ac7aca93814d4f032d236"
+                "reference": "948a4defbe2a571cc4460725015b8e98b7060f2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3e377fdfd0cda4e1412ac7aca93814d4f032d236",
-                "reference": "3e377fdfd0cda4e1412ac7aca93814d4f032d236",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/948a4defbe2a571cc4460725015b8e98b7060f2d",
+                "reference": "948a4defbe2a571cc4460725015b8e98b7060f2d",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2021-05-06T18:13:26+00:00"
+            "time": "2021-05-07T18:12:43+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -2286,16 +2286,16 @@
         },
         {
             "name": "keboola/staging-provider",
-            "version": "dev-odin-PS-2159",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/staging-provider.git",
-                "reference": "d3b3b82cfc83335f9bbc5b7ba517cc18fbe4a8f4"
+                "reference": "97b1ecc1773488176e9b811d466ac252e14223fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/staging-provider/zipball/d3b3b82cfc83335f9bbc5b7ba517cc18fbe4a8f4",
-                "reference": "d3b3b82cfc83335f9bbc5b7ba517cc18fbe4a8f4",
+                "url": "https://api.github.com/repos/keboola/staging-provider/zipball/97b1ecc1773488176e9b811d466ac252e14223fd",
+                "reference": "97b1ecc1773488176e9b811d466ac252e14223fd",
                 "shasum": ""
             },
             "require": {
@@ -2328,7 +2328,7 @@
                 "keboola",
                 "staging-provider"
             ],
-            "time": "2021-05-07T15:12:26+00:00"
+            "time": "2021-05-10T15:17:21+00:00"
         },
         {
             "name": "keboola/storage-api-client",
@@ -7247,18 +7247,9 @@
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "1.0.0",
-            "alias_normalized": "1.0.0.0",
-            "version": "dev-odin-PS-2159",
-            "package": "keboola/staging-provider"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "keboola/staging-provider": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -21,23 +21,14 @@ use Keboola\OutputMapping\Exception\InvalidOutputException;
 use Keboola\OutputMapping\Staging\StrategyFactory as OutputStrategyFactory;
 use Keboola\OutputMapping\Writer\FileWriter;
 use Keboola\OutputMapping\Writer\TableWriter;
-use Keboola\StagingProvider\Staging\Workspace\AbsWorkspaceStaging;
-use Keboola\StagingProvider\WorkspaceProviderFactory\ExistingFilesystemWorkspaceProviderFactory;
-use Keboola\StagingProvider\WorkspaceProviderFactory\ExistingFileWorkspaceProviderFactory;
-use Keboola\StagingProvider\WorkspaceProviderFactory\ExistingWorkspaceProviderFactory;
 use Keboola\StorageApi\ClientException;
-use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Exception;
-use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
-use Keboola\StorageApi\Options\Components\ListConfigurationWorkspacesOptions;
 use Keboola\StorageApi\Options\FileUploadOptions;
-use Keboola\StorageApi\Workspaces;
 use Keboola\StorageApiBranch\ClientWrapper;
 use Keboola\StagingProvider\InputProviderInitializer;
 use Keboola\StagingProvider\OutputProviderInitializer;
 use Keboola\StagingProvider\Provider\AbstractStagingProvider;
 use Keboola\StagingProvider\Provider\WorkspaceStagingProvider;
-use Keboola\StagingProvider\WorkspaceProviderFactory\ComponentWorkspaceProviderFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -147,20 +138,14 @@ class DataLoader implements DataLoaderInterface
             we need the base dir here */
         $dataDirectory = dirname($this->dataDirectory);
 
+        $workspaceProviderFactoryFactory = new WorkspaceProviderFactoryFactory($this->logger, $this->clientWrapper);
         /* There can only be one workspace type (ensured in validateStagingSetting()) - so we're checking
             just input staging here (because if it is workspace, it must be the same as output mapping). */
-        if ($this->configId && ($this->getStagingStorageInput() === InputStrategyFactory::WORKSPACE_ABS)) {
-            // ABS workspaces are persistent, but only if configId is present
-            $workspaceProviderFactory = $this->getWorkspaceFactoryForPersistentAbsWorkspace();
-        } else {
-            $workspaceProviderFactory = new ComponentWorkspaceProviderFactory(
-                new Components($this->clientWrapper->getBasicClient()),
-                new Workspaces($this->clientWrapper->getBasicClient()),
-                $this->component->getId(),
-                $this->configId
-            );
-            $this->logger->info('Created a new ephemeral workspace.');
-        }
+        $workspaceProviderFactory = $workspaceProviderFactoryFactory->getWorkspaceProviderFactory(
+            $this->getStagingStorageInput(),
+            $this->component,
+            $this->configId
+        );
         $inputProviderInitializer = new InputProviderInitializer(
             $this->inputStrategyFactory,
             $workspaceProviderFactory,
@@ -179,45 +164,6 @@ class DataLoader implements DataLoaderInterface
         $outputProviderInitializer->initializeProviders(
             $this->getStagingStorageOutput(),
             $tokenInfo
-        );
-    }
-
-    private function getWorkspaceFactoryForPersistentAbsWorkspace()
-    {
-        // ABS workspaces are persistent, but only if configId is present
-        $componentsApi = new Components($this->clientWrapper->getBasicClient());
-        $listOptions = (new ListConfigurationWorkspacesOptions())
-            ->setComponentId($this->component->getId())
-            ->setConfigurationId($this->configId);
-        $workspaces = $componentsApi->listConfigurationWorkspaces($listOptions);
-        if (count($workspaces) === 0) {
-            $workspace = $componentsApi->createConfigurationWorkspace(
-                $this->component->getId(),
-                $this->configId,
-                ['backend' => AbsWorkspaceStaging::getType()]
-            );
-            $workspaceId = $workspace['id'];
-            $connectionString = $workspace['connection']['connectionString'];
-            $this->logger->info(sprintf('Created a new persistent workspace "%s".', $workspaceId));
-        } elseif (count($workspaces) === 1) {
-            $workspaceId = $workspaces[0]['id'];
-            $workspaceApi = new Workspaces($this->clientWrapper->getBasicClient());
-            $connectionString = $workspaceApi->resetWorkspacePassword($workspaceId)['connectionString'];
-            $this->logger->info(sprintf('Reusing persistent workspace "%s".', $workspaceId));
-        } else {
-            throw new ApplicationException(sprintf(
-                'Multiple workspaces (total %s) found (IDs: %s, %s) for configuration "%s" of component "%s".',
-                count($workspaces),
-                $workspaces[0]['id'],
-                $workspaces[1]['id'],
-                $this->configId,
-                $this->component->getId()
-            ));
-        }
-        return new ExistingFilesystemWorkspaceProviderFactory(
-            new Workspaces($this->clientWrapper->getBasicClient()),
-            $workspaceId,
-            $connectionString
         );
     }
 

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -429,9 +429,11 @@ class DataLoader implements DataLoaderInterface
     public function cleanWorkspace()
     {
         $cleanedProviders = [];
-        foreach (array_merge($this->inputStrategyFactory->getStrategyMap(),
-            $this->outputStrategyFactory->getStrategyMap()) as $stagingDefinition
-        ) {
+        $maps = array_merge(
+            $this->inputStrategyFactory->getStrategyMap(),
+            $this->outputStrategyFactory->getStrategyMap()
+        );
+        foreach ($maps as $stagingDefinition) {
             foreach ($this->getStagingProviders($stagingDefinition) as $stagingProvider) {
                 if (!$stagingProvider instanceof WorkspaceStagingProvider) {
                     continue;

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -429,8 +429,6 @@ class DataLoader implements DataLoaderInterface
     public function cleanWorkspace()
     {
         $cleanedProviders = [];
-        /* Find the workspace to cleanup - working only with inputStrategyFactory, but the workspaceproviders
-        are shared between input and output, so it's "ok" */
         foreach (array_merge($this->inputStrategyFactory->getStrategyMap(),
             $this->outputStrategyFactory->getStrategyMap()) as $stagingDefinition
         ) {

--- a/src/Docker/Runner/DataLoader/WorkspaceProviderFactoryFactory.php
+++ b/src/Docker/Runner/DataLoader/WorkspaceProviderFactoryFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Keboola\DockerBundle\Docker\Runner\DataLoader;
+
+use Keboola\DockerBundle\Docker\Component;
+use Keboola\DockerBundle\Exception\ApplicationException;
+use Keboola\InputMapping\Staging\StrategyFactory as InputStrategyFactory;
+use Keboola\StagingProvider\Staging\Workspace\AbsWorkspaceStaging;
+use Keboola\StagingProvider\WorkspaceProviderFactory\ExistingFilesystemWorkspaceProviderFactory;
+use Keboola\StorageApi\Components;
+use Keboola\StorageApi\Options\Components\ListConfigurationWorkspacesOptions;
+use Keboola\StorageApi\Workspaces;
+use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StagingProvider\WorkspaceProviderFactory\ComponentWorkspaceProviderFactory;
+use Psr\Log\LoggerInterface;
+
+class WorkspaceProviderFactoryFactory
+{
+    private $logger;
+    private $clientWrapper;
+
+    public function __construct(LoggerInterface $logger, ClientWrapper $clientWrapper)
+    {
+        $this->logger = $logger;
+        $this->clientWrapper = $clientWrapper;
+    }
+
+    public function getWorkspaceProviderFactory($stagingStorage, Component $component, $configId)
+    {
+        /* There can only be one workspace type (ensured in validateStagingSetting()) - so we're checking
+            just input staging here (because if it is workspace, it must be the same as output mapping). */
+        if ($configId && ($stagingStorage === InputStrategyFactory::WORKSPACE_ABS)) {
+            // ABS workspaces are persistent, but only if configId is present
+            $workspaceProviderFactory = $this->getWorkspaceFactoryForPersistentAbsWorkspace($component, $configId);
+        } else {
+            $workspaceProviderFactory = new ComponentWorkspaceProviderFactory(
+                new Components($this->clientWrapper->getBasicClient()),
+                new Workspaces($this->clientWrapper->getBasicClient()),
+                $component->getId(),
+                $configId
+            );
+            $this->logger->info('Created a new ephemeral workspace.');
+        }
+        return $workspaceProviderFactory;
+    }
+
+    private function getWorkspaceFactoryForPersistentAbsWorkspace(Component $component, $configId)
+    {
+        // ABS workspaces are persistent, but only if configId is present
+        $componentsApi = new Components($this->clientWrapper->getBasicClient());
+        $listOptions = (new ListConfigurationWorkspacesOptions())
+            ->setComponentId($component->getId())
+            ->setConfigurationId($configId);
+        $workspaces = $componentsApi->listConfigurationWorkspaces($listOptions);
+        if (count($workspaces) === 0) {
+            $workspace = $componentsApi->createConfigurationWorkspace(
+                $component->getId(),
+                $configId,
+                ['backend' => AbsWorkspaceStaging::getType()]
+            );
+            $workspaceId = $workspace['id'];
+            $connectionString = $workspace['connection']['connectionString'];
+            $this->logger->info(sprintf('Created a new persistent workspace "%s".', $workspaceId));
+        } elseif (count($workspaces) === 1) {
+            $workspaceId = $workspaces[0]['id'];
+            $workspaceApi = new Workspaces($this->clientWrapper->getBasicClient());
+            $connectionString = $workspaceApi->resetWorkspacePassword($workspaceId)['connectionString'];
+            $this->logger->info(sprintf('Reusing persistent workspace "%s".', $workspaceId));
+        } else {
+            throw new ApplicationException(sprintf(
+                'Multiple workspaces (total %s) found (IDs: %s, %s) for configuration "%s" of component "%s".',
+                count($workspaces),
+                $workspaces[0]['id'],
+                $workspaces[1]['id'],
+                $configId,
+                $component->getId()
+            ));
+        }
+        return new ExistingFilesystemWorkspaceProviderFactory(
+            new Workspaces($this->clientWrapper->getBasicClient()),
+            $workspaceId,
+            $connectionString
+        );
+    }
+}


### PR DESCRIPTION
Řeší dohromady, protože jedno bez druhýho nejde (kvůli kontrole duplicitních workspace):
https://keboola.atlassian.net/browse/PS-2159
https://keboola.atlassian.net/browse/PS-2162

Dávám to jako draft, protože tam je dev závislost, závisí na https://github.com/keboola/staging-provider/pull/9

Plus mám teda vlastně jednu nejasnost - jestli to zapnem všude všem, nebo to budem nějak řešit přes fičuru (s tím souvisí failnutý tento test https://dev.azure.com/keboola-dev/docker-runner/_build/results?buildId=9302&view=logs&j=00172958-dc2f-5a07-7f65-b85e47f36adc&t=d87b4090-a97e-58d5-e3ab-66384d653296&l=2029 - protože workspace se nesmaže).

Já bych nakonec byl asi pro to, to zapnout všem, protože to je fíčura, která je stejně schovaná za sparkem a není běžně dostupná, i když je to trošku nečistý, protože papírově je ABS workspace public. Kompoty, který používají ABS workspace jsou:
`keboola-test.ex-hello-world` 
`keboola.databricks-transformation` 
`keboola.runner-workspace-abs-test`
