### PR TITLE
feat: record output continuously during execution

### DIFF
--- a/Tests/Runner/RunnerConfigRowsTest.php
+++ b/Tests/Runner/RunnerConfigRowsTest.php
@@ -154,13 +154,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $config['storage']['output']['tables'][0]['destination'] = 'in.c-runner-test.mytable-2';
         $jobDefinition2 = new JobDefinition($config, $this->getComponent());
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable'));
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable-2'));
@@ -214,13 +216,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $config['storage']['output']['tables'][0]['destination'] = 'in.c-runner-test.mytable-2';
         $jobDefinition2 = new JobDefinition($config, $componentData);
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable'));
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable-2'));
@@ -268,13 +272,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         ], $this->getComponent(), 'my-config', 1, [], 'row-2');
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            ['row-2']
+            ['row-2'],
+            $outputs
         );
         self::assertFalse($this->getClient()->tableExists('in.c-runner-test.mytable'));
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable-2'));
@@ -299,26 +305,30 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $runner = $this->getRunner();
         self::expectException(UserException::class);
         self::expectExceptionMessage('None of rows "row-2" was found.');
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            ['row-2']
+            ['row-2'],
+            $outputs
         );
     }
 
     public function testRunEmptyJobDefinitions()
     {
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             [],
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue(true);
     }
@@ -365,13 +375,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         ], $this->getComponent(), 'my-config', 1, [], 'disabled-row', true);
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains(
             'Skipping disabled configuration: my-config, version: 1, row: disabled-row'
@@ -433,13 +445,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         );
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            ['disabled-row']
+            ['disabled-row'],
+            $outputs
         );
         self::assertTrue($this->getRunnerHandler()->hasInfoThatContains(
             'Force running disabled configuration: my-config, version: 1, row: disabled-row'
@@ -491,13 +505,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
 
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         $metadata = new Metadata($this->getClient());
         $table1Metadata = $this->getMetadataValues($metadata->listTableMetadata('in.c-runner-test.mytable'));
@@ -552,13 +568,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $jobDefinition1 = new JobDefinition($config, $this->getComponent(), 'runner-configuration', null, [], 'row-1');
         $jobDefinition2 = new JobDefinition($config, $this->getComponent(), 'runner-configuration', null, [], 'row-2');
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             [$jobDefinition1, $jobDefinition2],
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
@@ -630,13 +648,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         $jobDefinition1 = new JobDefinition($configData, new Component($componentData), 'runner-configuration', null, [], 'row-1');
         $jobDefinition2 = new JobDefinition($configData, new Component($componentData), 'runner-configuration', null, [], 'row-2');
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             [$jobDefinition1, $jobDefinition2],
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $configuration = $component->getConfiguration('docker-demo', 'runner-configuration');
@@ -694,13 +714,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
         );
         $jobDefinitions = [$jobDefinition1, $jobDefinition2];
         $runner = $this->getRunner();
-        $outputs = $runner->run(
+        $outputs = [];
+        $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertCount(2, $outputs);
         self::assertCount(1, $outputs[0]->getImages());
@@ -819,13 +841,15 @@ class RunnerConfigRowsTest extends BaseRunnerTest
 
         $jobDefinitions = [$jobDefinition1];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            ['row-1']
+            ['row-1'],
+            $outputs
         );
 
         // the script logs all the input files, so fileId2 should be there, but not fileId1

--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -5,6 +5,7 @@ namespace Keboola\DockerBundle\Tests\Runner;
 use Keboola\Csv\CsvFile;
 use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Docker\JobDefinition;
+use Keboola\DockerBundle\Docker\Runner\Output;
 use Keboola\DockerBundle\Docker\Runner\StateFile;
 use Keboola\DockerBundle\Docker\Runner\UsageFile\NullUsageFile;
 use Keboola\DockerBundle\Docker\Runner\UsageFile\UsageFileInterface;
@@ -250,7 +251,8 @@ class RunnerTest extends BaseRunnerTest
         ];
         $this->setClientMock($clientMock);
         $runner = $this->getRunner();
-        $outputs = $runner->run(
+        $outputs = [];
+        $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
                 uniqid('test-'),
@@ -261,7 +263,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertEquals(
             [
@@ -395,7 +398,8 @@ class RunnerTest extends BaseRunnerTest
         ];
         $this->setClientMock($clientMock);
         $runner = $this->getRunner();
-        $outputs = $runner->run(
+        $outputs = [];
+        $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
                 uniqid('test-'),
@@ -406,7 +410,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertEquals(
             [
@@ -466,6 +471,7 @@ class RunnerTest extends BaseRunnerTest
         ];
         $configId = uniqid('test-');
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -477,7 +483,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();
@@ -525,6 +532,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -536,7 +544,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         $cfg = $cmp->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
         self::assertEquals([
@@ -593,6 +602,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -604,7 +614,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         self::assertTrue($this->getClient()->tableExists('out.c-keboola-docker-demo-sync-runner-configuration.sliced'));
@@ -641,6 +652,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -652,7 +664,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
@@ -697,6 +710,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -708,7 +722,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         $component = new Components($this->getClient());
         $configuration = $component->getConfiguration('keboola.docker-demo-sync', 'runner-configuration');
@@ -755,7 +770,8 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
-        $output = $runner->run(
+        $outputs = [];
+        $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
                 'runner-configuration',
@@ -766,9 +782,10 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
-        $this->assertNotEmpty($output);
+        $this->assertNotEmpty($outputs);
     }
 
     public function testExecutorStoreStateWithProcessor()
@@ -813,6 +830,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -824,7 +842,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $component = new Components($this->getClient());
@@ -897,6 +916,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             [
                 new JobDefinition($configData1, new Component($componentData), 'runner-configuration', 'v123', [], 'row-1'),
@@ -906,7 +926,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $component = new Components($this->getClient());
@@ -978,6 +999,7 @@ class RunnerTest extends BaseRunnerTest
 
         $runner = $this->getRunner();
         try {
+            $outputs = [];
             $runner->run(
                 [
                     new JobDefinition($configData1, new Component($componentData), 'runner-configuration', 'v123', [], 'row-1'),
@@ -986,7 +1008,8 @@ class RunnerTest extends BaseRunnerTest
                 'run',
                 '1234567',
                 new NullUsageFile(),
-                []
+                [],
+                $outputs
             );
         } catch (UserException $e) {
             self::assertStringContainsString(
@@ -1071,6 +1094,7 @@ class RunnerTest extends BaseRunnerTest
 
         $runner = $this->getRunner();
         try {
+            $outputs = [];
             $runner->run(
                 [
                     new JobDefinition($configData1, new Component($componentData), 'runner-configuration', 'v123', [], 'row-1'),
@@ -1080,7 +1104,8 @@ class RunnerTest extends BaseRunnerTest
                 'run',
                 '1234567',
                 new NullUsageFile(),
-                []
+                [],
+                $outputs
             );
         } catch (UserException $e) {
             self::assertStringContainsString(
@@ -1156,6 +1181,7 @@ class RunnerTest extends BaseRunnerTest
         ];
 
         try {
+            $outputs = [];
             $runner->run(
                 $this->prepareJobDefinitions(
                     $componentData,
@@ -1167,7 +1193,8 @@ class RunnerTest extends BaseRunnerTest
                 'run',
                 '1234567',
                 new NullUsageFile(),
-                []
+                [],
+                $outputs
             );
             self::fail('Must fail with user error');
         } catch (UserException $e) {
@@ -1255,6 +1282,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setConfiguration($configData);
         $component->addConfiguration($configuration);
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1266,7 +1294,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();
@@ -1359,6 +1388,7 @@ class RunnerTest extends BaseRunnerTest
         $configuration->setConfiguration($configData);
         $component->addConfiguration($configuration);
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1370,7 +1400,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();
@@ -1409,6 +1440,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1420,7 +1452,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $component = new Components($this->getClient());
@@ -1451,6 +1484,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1462,7 +1496,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $component = new Components($this->getClient());
@@ -1502,6 +1537,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1513,7 +1549,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         $metadataApi = new Metadata($this->getClient());
         $bucketMetadata = $metadataApi->listBucketMetadata('in.c-keboola-docker-demo-sync');
@@ -1557,6 +1594,7 @@ class RunnerTest extends BaseRunnerTest
 
         self::expectException(UserException::class);
         self::expectExceptionMessage('Unrecognized option "filterByRunId');
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1568,7 +1606,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 
@@ -1612,6 +1651,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1623,7 +1663,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         self::assertTrue($this->getClient()->tableExists('in.c-keboola-docker-demo-sync-runner-configuration.sliced'));
@@ -1672,6 +1713,7 @@ class RunnerTest extends BaseRunnerTest
 
         self::expectException(UserException::class);
         self::expectExceptionMessage("No such file or directory: '/data/in/tables/source.csv'");
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1683,7 +1725,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 
@@ -1732,6 +1775,7 @@ class RunnerTest extends BaseRunnerTest
 
         self::expectException(UserException::class);
         self::expectExceptionMessage("No such file or directory: '/data/in/tables/source.csv'");
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -1743,7 +1787,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 
@@ -1768,21 +1813,34 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
-        self::expectException(ApplicationException::class);
-        self::expectExceptionMessage(
-            'developer-portal-v2/' .
-            'keboola.python-transformation:latest container \'1234567-norunid--0-keboola-docker-demo-sync\'' .
-            ' failed: (2) Class 2 error'
-        );
-
-        $runner->run(
-            $this->prepareJobDefinitions($componentData, 'runner-configuration', $configurationData, []),
-            'run',
-            'run',
-            '1234567',
-            new NullUsageFile(),
-            []
-        );
+        try {
+            $outputs = [];
+            $runner->run(
+                $this->prepareJobDefinitions($componentData, 'runner-configuration', $configurationData, []),
+                'run',
+                'run',
+                '1234567',
+                new NullUsageFile(),
+                [],
+                $outputs
+            );
+        } catch (ApplicationException $e) {
+            self::assertStringContainsString(
+                'developer-portal-v2/' .
+                'keboola.python-transformation:latest container \'1234567-norunid--0-keboola-docker-demo-sync\'' .
+                ' failed: (2) Class 2 error',
+                $e->getMessage()
+            );
+            self::assertCount(1, $outputs);
+            /** @var Output $output */
+            $output = $outputs[0];
+            self::assertEquals('v123', $output->getConfigVersion());
+            self::assertNull($output->getInputFileStateList());
+            self::assertCount(1, $output->getImages());
+            self::assertArrayHasKey('id', $output->getImages()[0]);
+            self::assertArrayHasKey('digests', $output->getImages()[0]);
+            self::assertEquals('developer-portal-v2/keboola.python-transformation:latest', $output->getImages()[0]['id']);
+        }
     }
 
     public function testExecutorUserError()
@@ -1808,13 +1866,15 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
         self::expectException(UserException::class);
         self::expectExceptionMessage('Class 1 error');
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions($componentData, 'runner-configuration', $configurationData, []),
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 
@@ -1844,13 +1904,15 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
         self::expectException(UserException::class);
         self::expectExceptionMessage('Class 2 error');
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions($componentData, 'runner-configuration', $configurationData, []),
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 
@@ -1881,13 +1943,15 @@ class RunnerTest extends BaseRunnerTest
 
         self::expectException(ApplicationException::class);
         self::expectExceptionMessage('Component definition is invalid');
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions($componentData, 'runner-configuration', $configurationData, []),
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 
@@ -1926,7 +1990,16 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
         self::expectException(UserException::class);
         self::expectExceptionMessage('Unrecognized option "foo" under "container.storage.input.tables.0"');
-        $runner->run($this->prepareJobDefinitions($componentData, 'runner-configuration', $config, []), 'run', 'run', '1234567', new NullUsageFile(), []);
+        $outputs = [];
+        $runner->run(
+            $this->prepareJobDefinitions($componentData, 'runner-configuration', $config, []),
+            'run',
+            'run',
+            '1234567',
+            new NullUsageFile(),
+            [],
+            $outputs
+        );
     }
 
     public function testExecutorInvalidInputMapping2()
@@ -1973,7 +2046,16 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
         self::expectException(UserException::class);
         self::expectExceptionMessage('Invalid type for path "container.storage.input.tables.0.columns.0".');
-        $runner->run($this->prepareJobDefinitions($componentData, 'runner-configuration', $config, []), 'run', 'run', '1234567', new NullUsageFile(), []);
+        $outputs = [];
+        $runner->run(
+            $this->prepareJobDefinitions($componentData, 'runner-configuration', $config, []),
+            'run',
+            'run',
+            '1234567',
+            new NullUsageFile(),
+            [],
+            $outputs
+        );
     }
 
     public function testExecutorSlicedFilesWithComponentRootUserFeature()
@@ -2019,6 +2101,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2030,7 +2113,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable'));
@@ -2085,6 +2169,7 @@ class RunnerTest extends BaseRunnerTest
         ];
 
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2096,7 +2181,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue($this->getClient()->tableExists('in.c-runner-test.mytable'));
     }
@@ -2134,6 +2220,7 @@ class RunnerTest extends BaseRunnerTest
             ]
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2145,7 +2232,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();
@@ -2183,6 +2271,7 @@ class RunnerTest extends BaseRunnerTest
             ],
         ];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2194,7 +2283,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();
@@ -2235,7 +2325,8 @@ class RunnerTest extends BaseRunnerTest
         ];
         $jobDefinition = new JobDefinition($configData, new Component($componentData), 'runner-configuration');
         $runner = $this->getRunner();
-        $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile, []);
+        $outputs = [];
+        $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile, [], $outputs);
         self::assertEquals(
             [[[
                 'metric' => 'kB',
@@ -2288,7 +2379,16 @@ class RunnerTest extends BaseRunnerTest
         $jobDefinition1 = new JobDefinition($configData, new Component($componentData), 'runner-configuration', null, [], 'row-1');
         $jobDefinition2 = new JobDefinition($configData, new Component($componentData), 'runner-configuration', null, [], 'row-2');
         $runner = $this->getRunner();
-        $runner->run([$jobDefinition1, $jobDefinition2], 'run', 'run', '987654', $usageFile, []);
+        $outputs = [];
+        $runner->run(
+            [$jobDefinition1, $jobDefinition2],
+            'run',
+            'run',
+            '987654',
+            $usageFile,
+            [],
+            $outputs
+        );
         self::assertEquals(
             [
                 [[
@@ -2334,9 +2434,10 @@ class RunnerTest extends BaseRunnerTest
         ];
         $jobDefinition = new JobDefinition($configData, new Component($componentData), 'runner-configuration');
         $runner = $this->getRunner();
-        $output = $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile, []);
-        self::assertCount(1, $output);
-        self::assertEquals("Script file /data/script.py\nScript finished", $output[0]->getProcessOutput());
+        $outputs = [];
+        $runner->run([$jobDefinition], 'run', 'run', '987654', $usageFile, [], $outputs);
+        self::assertCount(1, $outputs);
+        self::assertEquals("Script file /data/script.py\nScript finished", $outputs[0]->getProcessOutput());
     }
 
     public function testRunAdaptiveInputMapping()
@@ -2461,13 +2562,15 @@ class RunnerTest extends BaseRunnerTest
 
         $jobDefinitions = [$jobDefinition1];
         $runner = $this->getRunner();
+        $outputs = [];
         $runner->run(
             $jobDefinitions,
             'run',
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         // the script logs all the input files, so fileId2 should be there, but not fileId1
@@ -2535,6 +2638,7 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
 
         self::assertFalse($this->client->tableExists('out.c-runner-test.new-table'));
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2568,7 +2672,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $options = new ListConfigurationWorkspacesOptions();
@@ -2616,6 +2721,7 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
 
         try {
+            $outputs = [];
             $runner->run(
                 $this->prepareJobDefinitions(
                     $componentData,
@@ -2641,7 +2747,8 @@ class RunnerTest extends BaseRunnerTest
                 'run',
                 '1234567',
                 new NullUsageFile(),
-                []
+                [],
+                $outputs
             );
             self::fail('Must fail');
         } catch (UserException $e) {
@@ -2692,6 +2799,7 @@ class RunnerTest extends BaseRunnerTest
         $runner = $this->getRunner();
 
         self::assertFalse($this->client->tableExists('out.c-runner-test.new-table'));
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2718,7 +2826,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();
@@ -2769,6 +2878,7 @@ class RunnerTest extends BaseRunnerTest
         $components->addConfiguration($configuration);
         $runner = $this->getRunner();
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2803,7 +2913,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         // wait for the file to show up in the listing
         sleep(2);
@@ -2851,6 +2962,7 @@ class RunnerTest extends BaseRunnerTest
         $components->addConfiguration($configuration);
         $runner = $this->getRunner();
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2881,7 +2993,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         // wait for the file to show up in the listing
         sleep(2);
@@ -2930,6 +3043,7 @@ class RunnerTest extends BaseRunnerTest
         $components->addConfiguration($configuration);
         $runner = $this->getRunner();
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -2956,7 +3070,8 @@ class RunnerTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         // wait for the file to show up in the listing

--- a/Tests/RunnerPart2/BranchedWorkspaceTest.php
+++ b/Tests/RunnerPart2/BranchedWorkspaceTest.php
@@ -226,14 +226,17 @@ class BranchedWorkspaceTest extends BaseRunnerTest
             RUNNER_MAX_LOG_PORT
         );
 
-        return $runner->run(
+        $outputs = [];
+        $runner->run(
             [$jobDefinition],
             'run',
             'run',
             '123456',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
+        return $outputs;
     }
 
     /**

--- a/Tests/RunnerPart2/OutputTest.php
+++ b/Tests/RunnerPart2/OutputTest.php
@@ -30,5 +30,11 @@ class OutputTest extends TestCase
         );
         self::assertEquals('123', $output->getConfigVersion());
         self::assertSame($stateFileMock, $output->getStateFile());
+        self::assertNull($output->getInputFileStateList());
+        self::assertNull($output->getInputTableStateList());
+        self::assertNull($output->getDataLoader());
+        self::assertNull($output->getTableQueue());
+        $output->setConfigVersion(null);
+        self::assertNull($output->getConfigVersion());
     }
 }

--- a/Tests/RunnerPart2/OutputTest.php
+++ b/Tests/RunnerPart2/OutputTest.php
@@ -15,7 +15,11 @@ class OutputTest extends TestCase
             ['id' => 'apples', 'digests' => ['foo', 'baz']],
             ['id' => 'oranges', 'digests' => ['bar']]
         ];
-        $output = new Output($images, 'bazBar', '123', $stateFileMock);
+        $output = new Output();
+        $output->setImages($images);
+        $output->setOutput('bazBar');
+        $output->setConfigVersion('123');
+        $output->setStateFile($stateFileMock);
         self::assertEquals('bazBar', $output->getProcessOutput());
         self::assertEquals(
             [

--- a/Tests/RunnerPart2/Runner2Test.php
+++ b/Tests/RunnerPart2/Runner2Test.php
@@ -57,6 +57,7 @@ class Runner2Test extends BaseRunnerTest
         self::expectException(UserException::class);
         // touch: cannot touch '/data/out/tables/mytable.csv.gz/part1': Permission denied
         self::expectExceptionMessageMatches('/Permission denied/');
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -68,7 +69,8 @@ class Runner2Test extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
     }
 

--- a/Tests/backend-specific-tests/ABS/RunnerAbsTest.php
+++ b/Tests/backend-specific-tests/ABS/RunnerAbsTest.php
@@ -86,6 +86,7 @@ class RunnerAbsTest extends BaseRunnerTest
         $runner = $this->getRunner();
 
         self::assertFalse($this->client->tableExists('out.c-runner-test.new-table'));
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -112,7 +113,8 @@ class RunnerAbsTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $records = $this->getContainerHandler()->getRecords();

--- a/Tests/backend-specific-tests/Synapse/RunnerSynapseTest.php
+++ b/Tests/backend-specific-tests/Synapse/RunnerSynapseTest.php
@@ -144,6 +144,7 @@ class RunnerSynapseTest extends BaseRunnerTest
         $runner = $this->getRunner();
 
         self::assertFalse($this->client->tableExists('out.c-synapse-runner-test.new-table'));
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -177,7 +178,8 @@ class RunnerSynapseTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
 
         $options = new ListConfigurationWorkspacesOptions();
@@ -227,6 +229,7 @@ class RunnerSynapseTest extends BaseRunnerTest
         $components->addConfiguration($configuration);
         $runner = $this->getRunner();
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -251,7 +254,8 @@ class RunnerSynapseTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue($this->getContainerHandler()->hasInfoThatContains(sprintf('data/in/files/my_lovely_file.wtf/%s', $fileId)));
 
@@ -312,6 +316,7 @@ class RunnerSynapseTest extends BaseRunnerTest
         $components->addConfiguration($configuration);
         $runner = $this->getRunner();
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -342,7 +347,8 @@ class RunnerSynapseTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         self::assertTrue($this->getContainerHandler()->hasInfoThatContains(
             sprintf('data/in/files/my_lovely_file.wtf/%s', $fileId)
@@ -386,6 +392,7 @@ class RunnerSynapseTest extends BaseRunnerTest
         $components->addConfiguration($configuration);
         $runner = $this->getRunner();
 
+        $outputs = [];
         $runner->run(
             $this->prepareJobDefinitions(
                 $componentData,
@@ -411,7 +418,8 @@ class RunnerSynapseTest extends BaseRunnerTest
             'run',
             '1234567',
             new NullUsageFile(),
-            []
+            [],
+            $outputs
         );
         $data = $this->client->getTableDataPreview('out.c-synapse-runner-test.test-table');
         self::assertEquals("\"first\",\"second\"\n\"1a\",\"2b\"\n", $data);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,42 +7,42 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="bootstrap.php">
 
     <php>
         <server name="KERNEL_DIR" value="vendor/keboola/syrup/app/" />
     </php>
 
-    <testsuite name="base-tests">
-        <directory>Tests</directory>
-        <exclude>Tests/Command</exclude>
-        <exclude>Tests/Controller</exclude>
-        <exclude>Tests/Runner</exclude>
-        <exclude>Tests/RunnerPart2</exclude>
-        <exclude>Tests/Executor</exclude>
-        <exclude>Tests/Docker/Container</exclude>
-        <exclude>Tests/backend-specific-tests</exclude>
-    </testsuite>
-    <testsuite name="runner-tests">
-        <directory>Tests/Runner</directory>
-    </testsuite>
-    <testsuite name="runner-tests-2">
-        <directory>Tests/RunnerPart2</directory>
-    </testsuite>
-    <testsuite name="container-tests">
-        <directory>Tests/Docker/Container</directory>
-    </testsuite>
-    <testsuite name="s3-tests">
-        <directory>Tests/backend-specific-tests/S3</directory>
-    </testsuite>
-    <testsuite name="abs-tests">
-        <directory>Tests/backend-specific-tests/ABS</directory>
-    </testsuite>
-    <testsuite name="synapse-tests">
-        <directory>Tests/backend-specific-tests/Synapse</directory>
-    </testsuite>
-
+    <testsuites>
+	    <testsuite name="base-tests">
+	        <directory>Tests</directory>
+	        <exclude>Tests/Command</exclude>
+	        <exclude>Tests/Controller</exclude>
+	        <exclude>Tests/Runner</exclude>
+	        <exclude>Tests/RunnerPart2</exclude>
+	        <exclude>Tests/Executor</exclude>
+	        <exclude>Tests/Docker/Container</exclude>
+	        <exclude>Tests/backend-specific-tests</exclude>
+	    </testsuite>
+	    <testsuite name="runner-tests">
+	        <directory>Tests/Runner</directory>
+	    </testsuite>
+	    <testsuite name="runner-tests-2">
+	        <directory>Tests/RunnerPart2</directory>
+	    </testsuite>
+	    <testsuite name="container-tests">
+	        <directory>Tests/Docker/Container</directory>
+	    </testsuite>
+	    <testsuite name="s3-tests">
+	        <directory>Tests/backend-specific-tests/S3</directory>
+	    </testsuite>
+	    <testsuite name="abs-tests">
+	        <directory>Tests/backend-specific-tests/ABS</directory>
+	    </testsuite>
+	    <testsuite name="synapse-tests">
+	        <directory>Tests/backend-specific-tests/Synapse</directory>
+	    </testsuite>
+	</testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">.</directory>

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -207,14 +207,16 @@ class Runner
      * @param string $mode
      * @param string $jobId
      * @param UsageFileInterface $usageFile
-     * @return Output
+     * @param Output[] $outputs
      */
-    private function runRow(JobDefinition $jobDefinition, $action, $mode, $jobId, UsageFileInterface $usageFile)
+    private function runRow(JobDefinition $jobDefinition, $action, $mode, $jobId, UsageFileInterface $usageFile, array &$outputs)
     {
         $this->loggersService->getLog()->notice(
             "Using configuration id: " . $jobDefinition->getConfigId() . ' version:' . $jobDefinition->getConfigVersion()
             . ", row id: " . $jobDefinition->getRowId() . ", state: " . json_encode($jobDefinition->getState())
         );
+        $outputs[] = new Output();
+        $outputs[count($outputs)-1]->setConfigVersion($jobDefinition->getConfigVersion());
         $component = $jobDefinition->getComponent();
         $this->loggersService->setComponentId($component->getId());
 
@@ -266,6 +268,7 @@ class Runner
             $this->loggersService->getLog(),
             $jobDefinition->getRowId()
         );
+        $outputs[count($outputs)-1]->setStateFile($stateFile);
 
         $imageCreator = new ImageCreator(
             $this->encryptorFactory->getEncryptor(),
@@ -291,7 +294,7 @@ class Runner
         }
 
         try {
-            $output = $this->runComponent(
+            $this->runComponent(
                 $jobId,
                 $jobDefinition->getConfigId(),
                 $jobDefinition->getRowId(),
@@ -303,28 +306,27 @@ class Runner
                 $imageCreator,
                 $configFile,
                 $outputFilter,
-                $jobDefinition->getConfigVersion(),
                 $mode,
                 $inputTableStateList,
-                $inputFileStateList
+                $inputFileStateList,
+                $outputs[count($outputs)-1]
             );
         } catch (\Exception $e) {
             $dataLoader->cleanWorkspace();
             throw $e;
         }
-        return $output;
     }
 
     /**
      * @param JobDefinition[] $jobDefinitions
-     * @param $action
-     * @param $mode
-     * @param $jobId
-     * @param $usageFile
+     * @param string $action
+     * @param string $mode
+     * @param string $jobId
+     * @param UsageFileInterface $usageFile
      * @param array $rowIds
-     * @return Output[]
+     * @param Output[] $outputs
      */
-    public function run(array $jobDefinitions, $action, $mode, $jobId, UsageFileInterface $usageFile, array $rowIds)
+    public function run(array $jobDefinitions, $action, $mode, $jobId, UsageFileInterface $usageFile, array $rowIds, array &$outputs)
     {
         if ($rowIds) {
             $jobDefinitions = array_filter($jobDefinitions, function ($jobDefinition) use ($rowIds) {
@@ -365,7 +367,7 @@ class Runner
                 "Running component " . $jobDefinition->getComponentId() .
                 ' (row ' . $counter . ' of ' . count($jobDefinitions) . ')'
             );
-            $outputs[] = $this->runRow($jobDefinition, $action, $mode, $jobId, $usageFile);
+            $this->runRow($jobDefinition, $action, $mode, $jobId, $usageFile, $outputs);
             $this->loggersService->getLog()->info(
                 "Finished component " . $jobDefinition->getComponentId() .
                 ' (row ' . $counter . ' of ' . count($jobDefinitions) . ')'
@@ -381,7 +383,6 @@ class Runner
                 );
             }
         }
-        return $outputs;
     }
 
     private function waitForStorageJobs(array $outputs)
@@ -422,11 +423,10 @@ class Runner
      * @param ImageCreator $imageCreator
      * @param ConfigFile $configFile
      * @param OutputFilterInterface $outputFilter
-     * @param string $configVersion
      * @param string $mode
      * @param InputTableStateList $inputTableStateList
      * @param InputFileStateList $inputFileStateList
-     * @return Output
+     * @param Output $output
      * @throws ClientException
      */
     private function runComponent(
@@ -441,16 +441,16 @@ class Runner
         ImageCreator $imageCreator,
         ConfigFile $configFile,
         OutputFilterInterface $outputFilter,
-        $configVersion,
         $mode,
         InputTableStateList $inputTableStateList,
-        InputFileStateList $inputFileStateList
+        InputFileStateList $inputFileStateList,
+        Output $output
     ) {
         // initialize
         $workingDirectory->createWorkingDir();
         $storageState = $dataLoader->loadInputData($inputTableStateList, $inputFileStateList);
 
-        $output = $this->runImages($jobId, $configId, $rowId, $component, $usageFile, $workingDirectory, $imageCreator, $configFile, $stateFile, $outputFilter, $dataLoader, $configVersion, $mode);
+        $this->runImages($jobId, $configId, $rowId, $component, $usageFile, $workingDirectory, $imageCreator, $configFile, $stateFile, $outputFilter, $dataLoader, $mode, $output);
         $output->setInputTableStateList($storageState->getInputTableStateList());
         $output->setInputFileStateList($storageState->getInputFileStateList());
         $output->setDataLoader($dataLoader);
@@ -480,11 +480,10 @@ class Runner
      * @param OutputFilterInterface $outputFilter
      * @param DataLoaderInterface $dataLoader
      * @param string $mode
-     * @param string $configVersion
-     * @return Output
+     * @param Output $output
      * @throws ClientException
      */
-    private function runImages($jobId, $configId, $rowId, Component $component, UsageFileInterface $usageFile, WorkingDirectory $workingDirectory, ImageCreator $imageCreator, ConfigFile $configFile, StateFile $stateFile, OutputFilterInterface $outputFilter, DataLoaderInterface $dataLoader, $configVersion, $mode)
+    private function runImages($jobId, $configId, $rowId, Component $component, UsageFileInterface $usageFile, WorkingDirectory $workingDirectory, ImageCreator $imageCreator, ConfigFile $configFile, StateFile $stateFile, OutputFilterInterface $outputFilter, DataLoaderInterface $dataLoader, $mode, $output)
     {
         $images = $imageCreator->prepareImages();
         $this->loggersService->setVerbosity($component->getLoggerVerbosity());
@@ -500,7 +499,7 @@ class Runner
         $counter = 0;
         $imageDigests = [];
         $newState = [];
-        $outputMessage = '';
+        $output->setOutput('');
         foreach ($images as $priority => $image) {
             if ($image->isMain()) {
                 $stateFile->createStateFile();
@@ -526,6 +525,7 @@ class Runner
                 'id' => $image->getPrintableImageId(),
                 'digests' => $image->getPrintableImageDigests()
             ];
+            $output->setImages($imageDigests);
             $configFile->createConfigFile($image->getConfigData(), $outputFilter, $dataLoader->getWorkspaceCredentials());
 
             $containerIdParts = [
@@ -565,7 +565,7 @@ class Runner
             try {
                 $process = $container->run();
                 if ($image->isMain()) {
-                    $outputMessage = $process->getOutput();
+                    $output->setOutput($process->getOutput());
                     $newState = $stateFile->loadStateFromFile();
                 }
             } finally {
@@ -582,6 +582,5 @@ class Runner
             }
         }
         $stateFile->stashState($newState);
-        return new Output($imageDigests, $outputMessage, $configVersion, $stateFile);
     }
 }

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -215,8 +215,9 @@ class Runner
             "Using configuration id: " . $jobDefinition->getConfigId() . ' version:' . $jobDefinition->getConfigVersion()
             . ", row id: " . $jobDefinition->getRowId() . ", state: " . json_encode($jobDefinition->getState())
         );
-        $outputs[] = new Output();
-        $outputs[count($outputs)-1]->setConfigVersion($jobDefinition->getConfigVersion());
+        $currentOutput = new Output();
+        $outputs[] = $currentOutput;
+        $currentOutput->setConfigVersion($jobDefinition->getConfigVersion());
         $component = $jobDefinition->getComponent();
         $this->loggersService->setComponentId($component->getId());
 
@@ -268,7 +269,7 @@ class Runner
             $this->loggersService->getLog(),
             $jobDefinition->getRowId()
         );
-        $outputs[count($outputs)-1]->setStateFile($stateFile);
+        $currentOutput->setStateFile($stateFile);
 
         $imageCreator = new ImageCreator(
             $this->encryptorFactory->getEncryptor(),
@@ -309,7 +310,7 @@ class Runner
                 $mode,
                 $inputTableStateList,
                 $inputFileStateList,
-                $outputs[count($outputs)-1]
+                $currentOutput
             );
         } catch (\Exception $e) {
             $dataLoader->cleanWorkspace();

--- a/src/Docker/Runner/Output.php
+++ b/src/Docker/Runner/Output.php
@@ -18,7 +18,7 @@ class Output
      */
     private $output;
     /**
-     * @var string
+     * @var ?string
      */
     private $configVersion;
     /**
@@ -76,15 +76,15 @@ class Output
     }
 
     /**
-     * @param string $configVersion
+     * @param ?string $configVersion
      */
-    public function setConfigVersion(string $configVersion): void
+    public function setConfigVersion(?string $configVersion): void
     {
         $this->configVersion = $configVersion;
     }
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getConfigVersion()
     {

--- a/src/Docker/Runner/Output.php
+++ b/src/Docker/Runner/Output.php
@@ -44,18 +44,11 @@ class Output
     private $dataLoader;
 
     /**
-     * Output constructor.
-     *
      * @param array $images
-     * @param string $output
-     * @param $configVersion
      */
-    public function __construct(array $images, $output, $configVersion, $stateFile)
+    public function setImages(array $images): void
     {
         $this->images = $images;
-        $this->output = $output;
-        $this->configVersion = $configVersion;
-        $this->stateFile = $stateFile;
     }
 
     /**
@@ -67,11 +60,27 @@ class Output
     }
 
     /**
+     * @param string $output
+     */
+    public function setOutput(string $output): void
+    {
+        $this->output = $output;
+    }
+
+    /**
      * @return string
      */
     public function getProcessOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * @param string $configVersion
+     */
+    public function setConfigVersion(string $configVersion): void
+    {
+        $this->configVersion = $configVersion;
     }
 
     /**
@@ -133,6 +142,14 @@ class Output
     public function getTableQueue()
     {
         return $this->tableQueue;
+    }
+
+    /**
+     * @param StateFile $stateFile
+     */
+    public function setStateFile(StateFile $stateFile): void
+    {
+        $this->stateFile = $stateFile;
     }
 
     public function getStateFile()


### PR DESCRIPTION
second part of https://keboola.atlassian.net/browse/PS-2120

změna spočívá v tom, že v runneru se Output předává jako reference (a ne result) a průběžně se do něj zapisuje, tzn. v případě chyby se zaznamená co zaznamenat šlo. To se testuje v tomto testu https://github.com/keboola/docker-bundle/pull/586/files#diff-6b2ec2ed1ae655ab48823af049f5cd7a36ef3171a033ab145afb826f3ef9cf86R1816 změny v okolních testech jsou jen změna v signatuře metody. 

required for https://github.com/keboola/job-runner/pull/56