### PR TITLE
PS-2866 Pass MLFLOW_TRACKING_URI

### DIFF
--- a/Tests/RunnerPart2/EnvironmentTest.php
+++ b/Tests/RunnerPart2/EnvironmentTest.php
@@ -52,7 +52,8 @@ class EnvironmentTest extends TestCase
             STORAGE_API_URL,
             '572-xxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
             '1234',
-            'connection-string'
+            'connection-string',
+            'mlflow-uri'
         );
         $envs = $environment->getEnvironmentVariables(new OutputFilter());
         self::assertArrayHasKey('KBC_PROJECTID', $envs);
@@ -72,6 +73,7 @@ class EnvironmentTest extends TestCase
         self::assertEquals('1234', $envs['KBC_BRANCHID']);
         self::assertSame('aws', $envs['KBC_STAGING_FILE_PROVIDER']);
         self::assertSame('connection-string', $envs['AZURE_STORAGE_CONNECTION_STRING']);
+        self::assertSame('mlflow-uri', $envs['MLFLOW_TRACKING_URI']);
     }
 
     public function testExecutorForwardToken()
@@ -101,6 +103,7 @@ class EnvironmentTest extends TestCase
             STORAGE_API_URL,
             '572-xxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
             '',
+            null,
             null
         );
         $envs = $environment->getEnvironmentVariables(new OutputFilter());
@@ -122,6 +125,7 @@ class EnvironmentTest extends TestCase
         self::assertArrayNotHasKey('KBC_REALUSER', $envs);
         self::assertSame('aws', $envs['KBC_STAGING_FILE_PROVIDER']);
         self::assertArrayNotHasKey('AZURE_STORAGE_CONNECTION_STRING', $envs);
+        self::assertArrayNotHasKey('MLFLOW_TRACKING_URI', $envs);
     }
 
     public function testExecutorForwardTokenAndDetails()
@@ -147,6 +151,7 @@ class EnvironmentTest extends TestCase
             STORAGE_API_URL,
             '572-xxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
             '',
+            null,
             null
         );
         $envs = $environment->getEnvironmentVariables(new OutputFilter());
@@ -166,6 +171,7 @@ class EnvironmentTest extends TestCase
         self::assertArrayNotHasKey('KBC_BRANCHID', $envs);
         self::assertSame('aws', $envs['KBC_STAGING_FILE_PROVIDER']);
         self::assertArrayNotHasKey('AZURE_STORAGE_CONNECTION_STRING', $envs);
+        self::assertArrayNotHasKey('MLFLOW_TRACKING_URI', $envs);
     }
 
     public function testExecutorForwardDetails()
@@ -195,7 +201,8 @@ class EnvironmentTest extends TestCase
             STORAGE_API_URL,
             '572-xxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
             '',
-            'connection-string'
+            'connection-string',
+            'mlflow-uri'
         );
         $envs = $environment->getEnvironmentVariables(new OutputFilter());
         self::assertArrayHasKey('KBC_PROJECTID', $envs);
@@ -213,6 +220,7 @@ class EnvironmentTest extends TestCase
         self::assertArrayNotHasKey('KBC_BRANCHID', $envs);
         self::assertArrayNotHasKey('KBC_REALUSER', $envs);
         self::assertSame('aws', $envs['KBC_STAGING_FILE_PROVIDER']);
+        self::assertSame('mlflow-uri', $envs['MLFLOW_TRACKING_URI']);
     }
 
     public function testExecutorForwardDetailsSaml()
@@ -246,6 +254,7 @@ class EnvironmentTest extends TestCase
             STORAGE_API_URL,
             '572-xxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
             '',
+            null,
             null
         );
         $envs = $environment->getEnvironmentVariables(new OutputFilter());
@@ -265,5 +274,6 @@ class EnvironmentTest extends TestCase
         self::assertEquals('boo', $envs['KBC_REALUSER']);
         self::assertSame('aws', $envs['KBC_STAGING_FILE_PROVIDER']);
         self::assertArrayNotHasKey('AZURE_STORAGE_CONNECTION_STRING', $envs);
+        self::assertArrayNotHasKey('MLFLOW_TRACKING_URI', $envs);
     }
 }

--- a/src/Docker/Runner.php
+++ b/src/Docker/Runner.php
@@ -467,10 +467,13 @@ class Runner
         $newState = [];
         $output->setOutput('');
 
-        $mlflowAbsConnectionString = null;
+        $absConnectionString = null;
+        $mlflowUri = null;
         if ($component->allowMlflowArtifactsAccess()) {
             $sandboxesProject = $this->sandboxesApiClient->getProject();
-            $mlflowAbsConnectionString = $sandboxesProject->getMlflowAbsConnectionString();
+
+            $absConnectionString = $sandboxesProject->getMlflowAbsConnectionString();
+            $mlflowUri = $sandboxesProject->getMlflowUri();
         }
 
         foreach ($images as $priority => $image) {
@@ -493,7 +496,8 @@ class Runner
                 $this->clientWrapper->getBasicClient()->getApiUrl(),
                 $this->clientWrapper->getBasicClient()->getTokenString(),
                 $this->clientWrapper->getBranchId(),
-                $mlflowAbsConnectionString
+                $absConnectionString,
+                $mlflowUri
             );
             $imageDigests[] = [
                 'id' => $image->getPrintableImageId(),

--- a/src/Docker/Runner/Environment.php
+++ b/src/Docker/Runner/Environment.php
@@ -17,7 +17,8 @@ class Environment
     private ?string $configRowId;
     private string $token;
     private ?string $branchId;
-    private ?string $mlflowAbsConnectionString;
+    private ?string $absConnectionString;
+    private ?string $mlflowUri;
 
     public function __construct(
         ?string $configId,
@@ -29,7 +30,8 @@ class Environment
         string $url,
         string $token,
         ?string $branchId,
-        ?string $mlflowAbsConnectionString
+        ?string $absConnectionString,
+        ?string $mlflowUri
     ) {
         if ($configId) {
             $this->configId = $configId;
@@ -46,7 +48,8 @@ class Environment
         $this->token = $token;
         $this->configRowId = $configRowId;
         $this->branchId = $branchId;
-        $this->mlflowAbsConnectionString = $mlflowAbsConnectionString;
+        $this->absConnectionString = $absConnectionString;
+        $this->mlflowUri = $mlflowUri;
     }
 
     public function getEnvironmentVariables(OutputFilterInterface $outputFilter)
@@ -81,9 +84,14 @@ class Environment
             $envs['KBC_BRANCHID'] = (string) $this->branchId;
         }
 
-        if ($this->mlflowAbsConnectionString !== null) {
-            $envs['AZURE_STORAGE_CONNECTION_STRING'] = $this->mlflowAbsConnectionString;
+        if ($this->absConnectionString !== null) {
+            $envs['AZURE_STORAGE_CONNECTION_STRING'] = $this->absConnectionString;
         }
+
+        if ($this->mlflowUri !== null) {
+            $envs['MLFLOW_TRACKING_URI'] = $this->mlflowUri;
+        }
+
         return $envs;
     }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2866

Po nasazeni `AZURE_STORAGE_CONNECTION_STRING` jsme pri testovani objevil, ze bude potreba jeste propisovat jeste `MLFLOW_TRACKING_URI`, kteoru MLflow klient pouziva k nalezeni serveru.