### PR TITLE
allow container tcp keepalive override to 60s via component feature

### DIFF
--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -199,7 +199,7 @@ class ComponentTest extends TestCase
                 ],
             ],
             'features' => [
-                'container-root-user', 'dev-branch-configuration-unsafe', 'dev-branch-job-blocked', 'dev-mapping-allowed', 'container-tcpkeepalive-60s-overide'
+                'container-root-user', 'dev-branch-configuration-unsafe', 'dev-branch-job-blocked', 'dev-mapping-allowed', 'container-tcpkeepalive-60s-override'
             ],
         ];
         $component = new Component($componentData);
@@ -207,7 +207,7 @@ class ComponentTest extends TestCase
         self::assertTrue($component->allowBranchMapping());
         self::assertTrue($component->blockBranchJobs());
         self::assertTrue($component->branchConfigurationsAreUnsafe());
-        self::assertTrue($component->overideKeepalive60s());
+        self::assertTrue($component->overrideKeepalive60s());
     }
 
     public function testInvalidRepository()

--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -199,7 +199,7 @@ class ComponentTest extends TestCase
                 ],
             ],
             'features' => [
-                'container-root-user', 'dev-branch-configuration-unsafe', 'dev-branch-job-blocked', 'dev-mapping-allowed',
+                'container-root-user', 'dev-branch-configuration-unsafe', 'dev-branch-job-blocked', 'dev-mapping-allowed', 'container-tcpkeepalive-60s-overide'
             ],
         ];
         $component = new Component($componentData);
@@ -207,6 +207,7 @@ class ComponentTest extends TestCase
         self::assertTrue($component->allowBranchMapping());
         self::assertTrue($component->blockBranchJobs());
         self::assertTrue($component->branchConfigurationsAreUnsafe());
+        self::assertTrue($component->overideKeepalive60s());
     }
 
     public function testInvalidRepository()

--- a/Tests/Docker/Container/ContainerTest.php
+++ b/Tests/Docker/Container/ContainerTest.php
@@ -38,6 +38,14 @@ class ContainerTest extends BaseContainerTest
         self::assertEquals($expected, $container->getRunCommand('name'));
     }
 
+    public function testRunCommandWithKeepaliveOverrideUserFeature()
+    {
+        $imageConfiguration = $this->getImageConfiguration();
+        $imageConfiguration['features'] = ['container-tcpkeepalive-60s-override'];
+        $container = $this->getContainer($imageConfiguration, [], [], false);
+        self::assertStringContainsString(" --sysctl net.ipv4.tcp_keepalive_time=60", $container->getRunCommand('name'));
+    }
+
     public function testRunCommandContainerWithoutRootUserFeature()
     {
         $container = $this->getContainer($this->getImageConfiguration(), [], [], false);

--- a/src/Docker/Component.php
+++ b/src/Docker/Component.php
@@ -129,6 +129,14 @@ class Component
     /**
      * @return bool
      */
+    public function overideKeepalive60s()
+    {
+        return in_array('container-tcpkeepalive-60s-overide', $this->features);
+    }
+
+    /**
+     * @return bool
+     */
     public function blockBranchJobs()
     {
         return in_array('dev-branch-job-blocked', $this->features);

--- a/src/Docker/Component.php
+++ b/src/Docker/Component.php
@@ -129,9 +129,9 @@ class Component
     /**
      * @return bool
      */
-    public function overideKeepalive60s()
+    public function overrideKeepalive60s()
     {
-        return in_array('container-tcpkeepalive-60s-overide', $this->features);
+        return in_array('container-tcpkeepalive-60s-override', $this->features);
     }
 
     /**

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -402,6 +402,7 @@ class Container
             . $labels
             . " --name " . escapeshellarg($containerId)
             . (!$this->getImage()->getSourceComponent()->runAsRoot() ? ' --user $(id -u):$(id -g)' : "")
+            . ($this->getImage()->getSourceComponent()->overideKeepalive60s() ? ' --sysctl net.ipv4.tcp_keepalive_time=60' : "")
             . " " . escapeshellarg($this->getImage()->getFullImageId());
         return $command;
     }

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -402,7 +402,7 @@ class Container
             . $labels
             . " --name " . escapeshellarg($containerId)
             . (!$this->getImage()->getSourceComponent()->runAsRoot() ? ' --user $(id -u):$(id -g)' : "")
-            . ($this->getImage()->getSourceComponent()->overideKeepalive60s() ? ' --sysctl net.ipv4.tcp_keepalive_time=60' : "")
+            . ($this->getImage()->getSourceComponent()->overrideKeepalive60s() ? ' --sysctl net.ipv4.tcp_keepalive_time=60' : "")
             . " " . escapeshellarg($this->getImage()->getFullImageId());
         return $command;
     }


### PR DESCRIPTION
fixes https://keboola.atlassian.net/browse/SRE-3888
Tato uprava zavadza featuru komponenty `container-tcpkeepalive-60s-override` ktora umoznuje prenastavit OS parameter ip stacku `net.ipv4.tcp_keepalive_time` na 60 sekund (default 2 hodiny).  Cele je to kvoli CSAS ktorym sa zasekava oracle ex niekde na network trafficu a rucnym testovanim sme zistili ze ten keepAlive parameter pomoze.

Tento parameter je mozne zmenit len cez parameter `docker run` commandu:
```
root@aks-jobs-20151051-vmss00000J:/# docker run --rm busybox sysctl net.ipv4.tcp_keepalive_time
net.ipv4.tcp_keepalive_time = 7200
root@aks-jobs-20151051-vmss00000J:/# docker run --sysctl net.ipv4.tcp_keepalive_time=60 --rm busybox sysctl net.ipv4.tcp_keepalive_time
net.ipv4.tcp_keepalive_time = 60
```

ak to menim vo vnutri kontajneru tak to nefunguje
```
root@aks-jobs-20151051-vmss00000J:/# docker run --rm busybox sysctl -w net.ipv4.tcp_keepalive_time=60
sysctl: error setting key 'net.ipv4.tcp_keepalive_time': Read-only file system
```

tiez to neprebera hodnotu ak sa to zmeni na hostovi:

```
root@aks-jobs-20151051-vmss00000J:/# sysctl -w net.ipv4.tcp_keepalive_time=60
net.ipv4.tcp_keepalive_time = 60
root@aks-jobs-20151051-vmss00000J:/# sysctl net.ipv4.tcp_keepalive_time   
net.ipv4.tcp_keepalive_time = 60
root@aks-jobs-20151051-vmss00000J:/# docker run --rm busybox sysctl net.ipv4.tcp_keepalive_time   
net.ipv4.tcp_keepalive_time = 7200
```

### Tests
Otestoval som to tak ze som do produkce pushol zbuildovany job runner (https://github.com/keboola/job-runner/pull/151/files) tag `dev-kacurez-keepalive-feature-test-SRE-3888` s tymto branchom.
Potom som v AZ Testingu do komponenty python transformation pridal featuru `container-tcpkeepalive-60s-override` https://github.com/keboola/infrastructure-plugin-update-components/pull/238
a pustal transformaciu https://connection.east-us-2.azure.keboola-testing.com/admin/projects/61/queue/2074088 so `sleep(2000)`, vliezol do pusteneho podu a jeho containeru a overil ze ma nastaveny spravne net.ipv4.tcp_keepalive_time na 60 sekund vid:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/1412120/186220911-c65c0223-8c36-4313-b4eb-16fd9a921289.png">

### Co Dalej

popravde nie som si isty ako to nasadit, predpokladam postup:
- mergnut toto PR do branchu `odin-library-3`:
- composer update v job runner
- merge job-runner and run job-queue-daemon pipeline
je to spravne?

okrem toho este treba
- pridat ako povolenu featuru do developer portal ui ?
- zdokumentovat to, kde?
