### PR TITLE
ConfigFile  + Container Configuration

### DIFF
--- a/Tests/Docker/Configuration/ContainerConfigurationTest.php
+++ b/Tests/Docker/Configuration/ContainerConfigurationTest.php
@@ -173,6 +173,7 @@ class ContainerConfigurationTest extends TestCase
                     'image_tag' => '12.7.0',
                     'backend' => [
                         'type' => 'foo',
+                        'context' => 'wml',
                     ]
                 ],
             ],
@@ -180,6 +181,7 @@ class ContainerConfigurationTest extends TestCase
 
         self::assertSame([
             'type' => 'foo',
+            'context' => 'wml',
         ], $config['runtime']['backend']);
     }
 
@@ -204,6 +206,7 @@ class ContainerConfigurationTest extends TestCase
                 'runtime' => [
                     'backend' => [
                         'type' => 'foo',
+                        'context' => 'wml',
                         'bar' => 'baz',
                     ]
                 ],

--- a/Tests/Docker/Configuration/ContainerConfigurationTest.php
+++ b/Tests/Docker/Configuration/ContainerConfigurationTest.php
@@ -57,7 +57,8 @@ class ContainerConfigurationTest extends TestCase
                                 "key" => "val"
                             ]
                         ]
-                    ]
+                    ],
+                    'context' => 'wlm',
                 ],
                 "processors" => [
                     "before" => [
@@ -132,7 +133,8 @@ class ContainerConfigurationTest extends TestCase
                         "container" => 'my-container',
                         "connectionString" => 'aVeryLongString',
                         "account" => 'test'
-                    ]
+                    ],
+                    'context' => 'wlm',
                 ],
                 "processors" => [
                     "before" => [

--- a/Tests/Docker/Configuration/ContainerConfigurationTest.php
+++ b/Tests/Docker/Configuration/ContainerConfigurationTest.php
@@ -130,7 +130,8 @@ class ContainerConfigurationTest extends TestCase
                 "authorization" => [
                     "workspace" => [
                         "container" => 'my-container',
-                        "connectionString" => 'aVeryLongString'
+                        "connectionString" => 'aVeryLongString',
+                        "account" => 'test'
                     ]
                 ],
                 "processors" => [

--- a/Tests/Runner/ConfigFileTest.php
+++ b/Tests/Runner/ConfigFileTest.php
@@ -119,7 +119,6 @@ SAMPLE;
         // volatile parameters must not get stored
         self::assertArrayNotHasKey('foo', $config['parameters']);
         self::assertArrayNotHasKey('baz', $config['parameters']);
-        self::assertArrayNotHasKey('context', $config['authorization']);
 
         if ($expectedAuthContext) {
             self::assertArrayHasKey('context', $config['authorization']);

--- a/Tests/Runner/DataLoaderTest.php
+++ b/Tests/Runner/DataLoaderTest.php
@@ -250,7 +250,7 @@ class DataLoaderTest extends BaseDataLoaderTest
         );
         $dataLoader->storeOutput();
         $credentials = $dataLoader->getWorkspaceCredentials();
-        self::assertEquals(['host', 'warehouse', 'database', 'schema', 'user', 'password'], array_keys($credentials));
+        self::assertEquals(['host', 'warehouse', 'database', 'schema', 'user', 'password', 'account'], array_keys($credentials));
         self::assertNotEmpty($credentials['user']);
         self::assertNotNull($dataLoader->getWorkspaceBackendSize());
     }

--- a/src/Docker/Configuration/Container.php
+++ b/src/Docker/Configuration/Container.php
@@ -110,6 +110,7 @@ class Container extends Configuration
                         ->scalarNode("password")->end()
                         ->scalarNode("container")->end()
                         ->scalarNode("connectionString")->end()
+                        ->scalarNode("account")->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Docker/Configuration/Container.php
+++ b/src/Docker/Configuration/Container.php
@@ -113,6 +113,7 @@ class Container extends Configuration
                         ->scalarNode("account")->end()
                     ->end()
                 ->end()
+                ->scalarNode("context")->end()
             ->end()
         ->end();
 

--- a/src/Docker/Configuration/Container.php
+++ b/src/Docker/Configuration/Container.php
@@ -29,6 +29,7 @@ class Container extends Configuration
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('type')->end()
+                                ->scalarNode('context')->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Docker/Runner/ConfigFile.php
+++ b/src/Docker/Runner/ConfigFile.php
@@ -53,6 +53,7 @@ class ConfigFile
         // create configuration file injected into docker
         $adapter = new Adapter($this->format);
         try {
+            $backendContext = $configData['runtime']['backend']['context'] ?? null;
             // remove runtime parameters and processors which are not supposed to be passed into the container
             unset($configData['runtime']);
             unset($configData['processors']);
@@ -68,6 +69,9 @@ class ConfigFile
             }
             if ($workspaceCredentials) {
                 $configData['authorization']['workspace'] = $workspaceCredentials;
+            }
+            if ($backendContext) {
+                $configData['authorization']['context'] = $backendContext;
             }
 
             // action


### PR DESCRIPTION
Fixes https://keboola.atlassian.net/browse/PS-3919 + https://keboola.atlassian.net/browse/PS-3920

- Povolení `backend/context` a `workspace/account` v Container Configuration.
Testy padají viz https://keboola.slack.com/archives/CQB468K63/p1666704566912829 na spouštění testovací komponenty která nepovoluje extra fieldy v konfiguraci.