### PR TITLE
ECR - STS client timeouts

### DIFF
--- a/src/Docker/Image/AWSElasticContainerRegistry.php
+++ b/src/Docker/Image/AWSElasticContainerRegistry.php
@@ -48,6 +48,7 @@ class AWSElasticContainerRegistry extends Image
     {
         $stsClient = new StsClient([
             'region' => $this->getAwsRegion(),
+            'version' => '2011-06-15',
             'retries' => self::CONNECT_RETRIES,
             'connect_timeout' => self::CONNECT_TIMEOUT,
             'timeout' => self::TRANSFER_TIMEOUT,

--- a/src/Docker/Image/AWSElasticContainerRegistry.php
+++ b/src/Docker/Image/AWSElasticContainerRegistry.php
@@ -2,8 +2,10 @@
 
 namespace Keboola\DockerBundle\Docker\Image;
 
+use Aws\Credentials\CredentialProvider;
 use Aws\Ecr\EcrClient;
 use Aws\Result;
+use Aws\Sts\StsClient;
 use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Docker\Image;
 use Keboola\DockerBundle\Exception\ApplicationException;
@@ -44,12 +46,24 @@ class AWSElasticContainerRegistry extends Image
      */
     public function getLoginParams()
     {
+        $stsClient = new StsClient([
+            'region' => $this->getAwsRegion(),
+            'retries' => self::CONNECT_RETRIES,
+            'connect_timeout' => self::CONNECT_TIMEOUT,
+            'timeout' => self::TRANSFER_TIMEOUT,
+            'credentials' => false,
+        ]);
+        $awsCredentials = CredentialProvider::defaultProvider([
+            'region' => $this->getAwsRegion(),
+            'stsClient' => $stsClient,
+        ]);
         $ecrClient = new EcrClient(array(
             'region' => $this->getAwsRegion(),
             'version' => '2015-09-21',
             'retries' => self::CONNECT_RETRIES,
             'connect_timeout' => self::CONNECT_TIMEOUT,
             'timeout' => self::TRANSFER_TIMEOUT,
+            'credentials' => $awsCredentials,
         ));
         /** @var Result $authorization */
         $authorization = null;


### PR DESCRIPTION
FIXES: https://keboola.atlassian.net/browse/PS-3954

Nastavení timeoutů pro STS klienta při assume credentials.

Vychází z https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#assume-role-with-web-identity-provider Instance STS klienta by tam měla protéct přes parametry DefaultProvideru https://github.com/aws/aws-sdk-php/blob/cab6d4f830ce275a1742a3e35e2625917b006dd2/src/Credentials/CredentialProvider.php#L442

Nevím jak to vyzkoušet že se zkutečně správně zpropaguje ten klient.