### PR TITLE
Remove unnecessary DinD usage

### DIFF
--- a/Tests/RunnerPart2/WorkingDirectoryTest.php
+++ b/Tests/RunnerPart2/WorkingDirectoryTest.php
@@ -27,10 +27,8 @@ class WorkingDirectoryTest extends TestCase
         $workingDir->expects(self::exactly(2))
             ->method('getNormalizeCommand')
             ->will(self::onConsecutiveCalls(
-                'sleep 130 && sudo docker run --rm --volume=' . $temp->getTmpFolder() .
-                '/data:/data alpine sh -c \'chown 0 /data -R\'',
-                'sudo docker run --rm --volume=' . $temp->getTmpFolder() .
-                '/data:/data alpine sh -c \'chown ' . $uid . ' /data -R\''
+                'sleep 130 && sudo chown 0 ' . $temp->getTmpFolder() . ' -R',
+                'sudo chown' . $uid . ' ' . $temp->getTmpFolder() . ' -R'
             ));
 
         /** @var WorkingDirectory $workingDir */

--- a/src/Docker/Image/AWSElasticContainerRegistry.php
+++ b/src/Docker/Image/AWSElasticContainerRegistry.php
@@ -114,13 +114,10 @@ class AWSElasticContainerRegistry extends Image
     {
         $proxy = $this->getRetryProxy();
 
-        $command = "sudo docker run --rm -v /var/run/docker.sock:/var/run/docker.sock " .
-            "docker:1.11 sh -c " .
-            escapeshellarg(
-                "docker login " . $this->getLoginParams() .  " " .
-                "&& docker pull " . escapeshellarg($this->getFullImageId()) . " " .
-                "&& docker logout " . $this->getLogoutParams()
-            );
+        $command = "sudo docker login " . $this->getLoginParams() .  " " .
+            "&& sudo docker pull " . escapeshellarg($this->getFullImageId()) . " " .
+            "&& sudo docker logout " . $this->getLogoutParams();
+
         $process = Process::fromShellCommandline($command);
         $process->setTimeout(3600);
         try {

--- a/src/Docker/Runner/WorkingDirectory.php
+++ b/src/Docker/Runner/WorkingDirectory.php
@@ -58,9 +58,7 @@ class WorkingDirectory
     public function getNormalizeCommand()
     {
         $uid = trim((Process::fromShellCommandline('id -u'))->mustRun()->getOutput());
-        return "sudo docker run --rm --volume=" .
-            $this->workingDir . ":/data alpine sh -c 'chown {$uid} /data -R && "
-                . "chmod -R u+wrX /data'";
+        return "sudo chown {$uid} {$this->workingDir} -R && chmod -R u+wrX {$this->workingDir}";
     }
 
     public function normalizePermissions()


### PR DESCRIPTION
https://keboola.slack.com/archives/C04GXMDK88M
Instalace do runneru: https://github.com/keboola/job-runner/pull/179

Historicky se nektere veci delaly skrze `docker run`, coz vyzaduje pullnout image z DockerHubu a zacalo delat problemy s rate limitem. Jelikoz ale Queue2 pousti kazdy job v izolovanem Podu, nemelo by to uz byt potreba.