### PR TITLE
PST-1242 Validator for authorization.app_proxy in config

### DIFF
--- a/Tests/Docker/Configuration/Authorization/AppProxyDefinitionTest.php
+++ b/Tests/Docker/Configuration/Authorization/AppProxyDefinitionTest.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DockerBundle\Tests\Docker\Configuration\Authorization;
+
+use Keboola\DockerBundle\Docker\Configuration\Authorization\AppProxyDefinition;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+// phpcs:disable Generic.Files.LineLength.MaxExceeded -- so that we don't have to wrap error messages
+class AppProxyDefinitionTest extends TestCase
+{
+    public static function provideValidAppProxyAuthorizationConfig(): iterable
+    {
+        yield 'no auth' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'configured auth' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                        'type' => 'simple',
+                    ],
+                    [
+                        'id' => 'aad',
+                        'type' => 'oidc',
+                        'client_id' => 'foo',
+                        '#client_secret' => 'bar',
+                        'issuer_url' => 'https://example.com',
+                        'allowed_roles' => ['admin', 'guest'],
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/api',
+                        'auth_required' => true,
+                        'auth' => ['simple'],
+                    ],
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => true,
+                        'auth' => ['simple', 'aad'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /** @dataProvider provideValidAppProxyAuthorizationConfig */
+    public function testValidAppProxyAuthorizationConfig(?array $config): void
+    {
+        (new Processor())->processConfiguration(new AppProxyDefinition(), [
+            'app_proxy' => $config,
+        ]);
+        self::assertTrue(true);
+    }
+
+    public static function provideInvalidAppProxyAuthorizationConfig(): iterable
+    {
+        yield 'empty config' => [
+            'config' => [],
+            'error' => 'The child config "auth_providers" under "app_proxy" must be configured.',
+        ];
+
+        yield 'no auth rules' => [
+            'config' => [
+                'auth_providers' => [],
+            ],
+            'error' => 'The child config "auth_rules" under "app_proxy" must be configured.',
+        ];
+
+        yield 'no auth rule' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [],
+            ],
+            'error' => 'The path "app_proxy.auth_rules" should have at least 1 element(s) defined.',
+        ];
+
+        yield 'invalid auth rule (no type)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The child config "type" under "app_proxy.auth_rules.0" must be configured.',
+        ];
+
+        yield 'invalid auth rule (invalid type)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 1,
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy.auth_rules.0.type": value must be a string',
+        ];
+
+        yield 'invalid auth rule (empty type)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => '',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The path "app_proxy.auth_rules.0.type" cannot contain an empty value, but got "".',
+        ];
+
+        yield 'invalid auth rule (no auth_required)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                    ],
+                ],
+            ],
+            'error' => 'The child config "auth_required" under "app_proxy.auth_rules.0" must be configured.',
+        ];
+
+        yield 'invalid auth rule (invalid auth_required)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => 'x',
+                    ],
+                ],
+            ],
+            'error' => 'Invalid type for path "app_proxy.auth_rules.0.auth_required". Expected "bool", but got "string".',
+        ];
+
+        yield 'invalid auth rule (no auth when auth_required: true)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => true,
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy.auth_rules.0": "auth" value must be configured (only) when "auth_required" is true',
+        ];
+
+        yield 'invalid auth rule (empty auth when auth_required: true)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => true,
+                        'auth' => [],
+                    ],
+                ],
+            ],
+            'error' => 'The path "app_proxy.auth_rules.0.auth" should have at least 1 element(s) defined.',
+        ];
+
+        yield 'invalid auth rule (auth set when auth_required: false)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                        'auth' => ['foo'],
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy.auth_rules.0": "auth" value must be configured (only) when "auth_required" is true',
+        ];
+
+        yield 'invalid auth rule (unknown auth provider)' => [
+            'config' => [
+                'auth_providers' => [],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => true,
+                        'auth' => ['foo'],
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy": auth_rules.0.auth contains unknown auth providers: foo',
+        ];
+
+        yield 'invalid auth provider (no id)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'type' => 'simple',
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The child config "id" under "app_proxy.auth_providers.0" must be configured.',
+        ];
+
+        yield 'invalid auth provider (invalid id)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 1,
+                        'type' => 'simple',
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy.auth_providers.0.id": value must be a string',
+        ];
+
+        yield 'invalid auth provider (empty id)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => '',
+                        'type' => 'simple',
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The path "app_proxy.auth_providers.0.id" cannot contain an empty value, but got "".',
+        ];
+
+        yield 'invalid auth provider (no type)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The child config "type" under "app_proxy.auth_providers.0" must be configured.',
+        ];
+
+        yield 'invalid auth provider (invalid type)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                        'type' => 1,
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy.auth_providers.0.type": value must be a string',
+        ];
+
+        yield 'invalid auth provider (empty type)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                        'type' => '',
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The path "app_proxy.auth_providers.0.type" cannot contain an empty value, but got "".',
+        ];
+
+        yield 'invalid auth provider (invalid allowed_roles)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                        'type' => 'simple',
+                        'allowed_roles' => 'foo',
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'Invalid type for path "app_proxy.auth_providers.0.allowed_roles". Expected "array", but got "string"',
+        ];
+
+        yield 'invalid auth provider (empty allowed_roles)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                        'type' => 'simple',
+                        'allowed_roles' => [],
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'The path "app_proxy.auth_providers.0.allowed_roles" should have at least 1 element(s) defined.',
+        ];
+
+        yield 'invalid auth provider (invalid allowed_roles item)' => [
+            'config' => [
+                'auth_providers' => [
+                    [
+                        'id' => 'simple',
+                        'type' => 'simple',
+                        'allowed_roles' => [1],
+                    ],
+                ],
+                'auth_rules' => [
+                    [
+                        'type' => 'pathPrefix',
+                        'value' => '/',
+                        'auth_required' => false,
+                    ],
+                ],
+            ],
+            'error' => 'Invalid configuration for path "app_proxy.auth_providers.0.allowed_roles.0": value must be a string',
+        ];
+    }
+
+    /** @dataProvider provideInvalidAppProxyAuthorizationConfig */
+    public function testInvalidAppProxyAuthorizationConfig(array $config, string $error): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($error);
+
+        (new Processor())->processConfiguration(new AppProxyDefinition(), [
+            'app_proxy' => $config,
+        ]);
+    }
+
+    public function testEmptyAuthIsNotPresentInAuthRule(): void
+    {
+        $config = [
+            'auth_providers' => [],
+            'auth_rules' => [
+                [
+                    'type' => 'pathPrefix',
+                    'value' => '/',
+                    'auth_required' => false,
+                ],
+            ],
+        ];
+
+        $result = (new Processor())->processConfiguration(new AppProxyDefinition(), [
+            'app_proxy' => $config,
+        ]);
+
+        self::assertArrayNotHasKey('auth', $result['auth_rules'][0]);
+    }
+}

--- a/Tests/Docker/Configuration/Authorization/AuthorizationDefinitionTest.php
+++ b/Tests/Docker/Configuration/Authorization/AuthorizationDefinitionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DockerBundle\Tests\Docker\Configuration\Authorization;
+
+use Keboola\DockerBundle\Docker\Configuration\Authorization\AuthorizationDefinition;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+
+class AuthorizationDefinitionTest extends TestCase
+{
+    public static function provideValidAuthorizationConfig(): iterable
+    {
+        yield 'no auth' => [
+            'config' => [],
+        ];
+
+        yield 'configured oauth' => [
+            'config' => [
+                'oauth_api' => [
+                    'id' => '123',
+                    'version' => 2,
+                    'credentials' => [
+                        'key' => 'value',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'configured workspace' => [
+            'config' => [
+                'workspace' => [
+                    'container' => 'my-container',
+                    'connectionString' => 'aVeryLongString',
+                    'account' => 'test',
+                    'region' => 'mordor',
+                    'credentials' => [
+                        'client_id' => 'client123',
+                        'private_key' => 'very-secret-private-key',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'configured context' => [
+            'config' => [
+                'context' => 'wlm',
+            ],
+        ];
+
+        yield 'configured app proxy' => [
+            'config' => [
+                'app_proxy' => [
+                    'auth_providers' => [],
+                    'auth_rules' => [
+                        [
+                            'type' => 'pathPrefix',
+                            'value' => '/',
+                            'auth_required' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /** @dataProvider provideValidAuthorizationConfig */
+    public function testValidAuthorizationConfig(?array $config): void
+    {
+        (new Processor())->processConfiguration(new AuthorizationDefinition(), [
+            'authorization' => $config,
+        ]);
+        self::assertTrue(true);
+    }
+}

--- a/src/Docker/Configuration/Authorization/AppProxyDefinition.php
+++ b/src/Docker/Configuration/Authorization/AppProxyDefinition.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DockerBundle\Docker\Configuration\Authorization;
+
+use InvalidArgumentException;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class AppProxyDefinition implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('app_proxy');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('auth_providers')
+                    ->isRequired()
+                    ->arrayPrototype()
+                        ->ignoreExtraKeys(false)
+                        ->children()
+                            ->scalarNode('id')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->validate()
+                                    ->ifTrue(fn($v) => !is_string($v))
+                                    ->thenInvalid('value must be a string')
+                                ->end()
+                            ->end()
+                            ->scalarNode('type')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->validate()
+                                    ->ifTrue(fn($v) => !is_string($v))
+                                    ->thenInvalid('value must be a string')
+                                ->end()
+                            ->end()
+                            ->arrayNode('allowed_roles')
+                                ->requiresAtLeastOneElement()
+                                ->scalarPrototype()
+                                    ->cannotBeEmpty()
+                                    ->validate()
+                                        ->ifTrue(fn($v) => !is_string($v))
+                                        ->thenInvalid('value must be a string')
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('auth_rules')
+                    ->isRequired()
+                    ->requiresAtLeastOneElement()
+                    ->arrayPrototype()
+                        ->ignoreExtraKeys(false)
+                        ->children()
+                            ->scalarNode('type')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->validate()
+                                    ->ifTrue(fn($v) => !is_string($v))
+                                    ->thenInvalid('value must be a string')
+                                ->end()
+                            ->end()
+                            ->booleanNode('auth_required')
+                                ->isRequired()
+                            ->end()
+                            ->arrayNode('auth')
+                                ->requiresAtLeastOneElement()
+                                ->scalarPrototype()
+                                    ->cannotBeEmpty()
+                                    ->validate()
+                                        ->ifTrue(fn($v) => !is_string($v))
+                                        ->thenInvalid('value must be a string')
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->validate()
+                            ->ifTrue(fn($v) => $v['auth_required'] === (count($v['auth']) === 0))
+                            ->thenInvalid('"auth" value must be configured (only) when "auth_required" is true')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->validate()
+                ->always(function ($v) {
+                    $definedProviders = array_map(fn($provider) => $provider['id'], $v['auth_providers']);
+                    foreach ($v['auth_rules'] as $ruleId => $rule) {
+                        $invalidRuleProviders = array_diff($rule['auth'], $definedProviders);
+
+                        if (count($invalidRuleProviders) > 0) {
+                            throw new InvalidArgumentException(sprintf(
+                                'auth_rules.%s.auth contains unknown auth providers: %s',
+                                $ruleId,
+                                implode(', ', $invalidRuleProviders),
+                            ));
+                        }
+
+                        // arrayNode in config automatically defaults to empty array but auth_rule[].auth must not be
+                        // empty array, so we do manual cleanup
+                        if (!$rule['auth_required']) {
+                            unset($v['auth_rules'][$ruleId]['auth']);
+                        }
+                    }
+
+                    return $v;
+                })
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Docker/Configuration/Authorization/AuthorizationDefinition.php
+++ b/src/Docker/Configuration/Authorization/AuthorizationDefinition.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DockerBundle\Docker\Configuration\Authorization;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class AuthorizationDefinition implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('authorization');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('oauth_api')
+                    ->children()
+                        ->scalarNode('id')->end()
+                        ->scalarNode('version')->end()
+                        ->variableNode('credentials')->end()
+                    ->end()
+                ->end()
+                ->arrayNode('workspace')
+                    ->children()
+                        ->scalarNode('host')->end()
+                        ->scalarNode('account')->end()
+                        ->scalarNode('warehouse')->end()
+                        ->scalarNode('database')->end()
+                        ->scalarNode('schema')->end()
+                        ->scalarNode('region')->end()
+                        ->scalarNode('user')->end()
+                        ->scalarNode('password')->end()
+                        ->scalarNode('container')->end()
+                        ->scalarNode('connectionString')->end()
+                        ->variableNode('credentials')->end()
+                    ->end()
+                ->end()
+                ->scalarNode('context')->end()
+                ->append((new AppProxyDefinition())->getConfigTreeBuilder()->getRootNode())
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Docker/Configuration/Container.php
+++ b/src/Docker/Configuration/Container.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\DockerBundle\Docker\Configuration;
 
 use Keboola\DockerBundle\Docker\Configuration;
+use Keboola\DockerBundle\Docker\Configuration\Authorization\AuthorizationDefinition;
 use Keboola\InputMapping\Configuration\File as InputFile;
 use Keboola\InputMapping\Configuration\Table as InputTable;
 use Keboola\OutputMapping\Configuration\File as OutputFile;
@@ -95,35 +96,7 @@ class Container extends Configuration
         OutputTableFile::configureNode($outputTableFile);
 
         // authorization
-        $root->children()
-            ->arrayNode('authorization')
-            ->children()
-                ->arrayNode('oauth_api')
-                    ->children()
-                        ->scalarNode('id')->end()
-                        ->scalarNode('version')->end()
-                        ->variableNode('credentials')->end()
-                    ->end()
-                ->end()
-                ->arrayNode('workspace')
-                    ->children()
-                        ->scalarNode('host')->end()
-                        ->scalarNode('account')->end()
-                        ->scalarNode('warehouse')->end()
-                        ->scalarNode('database')->end()
-                        ->scalarNode('schema')->end()
-                        ->scalarNode('region')->end()
-                        ->scalarNode('user')->end()
-                        ->scalarNode('password')->end()
-                        ->scalarNode('container')->end()
-                        ->scalarNode('connectionString')->end()
-                        ->scalarNode('account')->end()
-                        ->variableNode('credentials')->end()
-                    ->end()
-                ->end()
-                ->scalarNode('context')->end()
-            ->end()
-        ->end();
+        $root->children()->append((new AuthorizationDefinition())->getConfigTreeBuilder()->getRootNode());
 
         // action
         $root->children()->scalarNode('action')->end();


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-1242

Validace `authorization.app_proxy`.
* pokryva to pouze fieldy, ktery jsou soucasti specifikace, ale pocita se s tim, ze ruzny typy rules/providers muzou mit dalsi cusotm fieldy (`ignoreExtraKeys`)
* nevaliduje se `type` rules/providers, aby se sem nemuselo sahat pokazde, kdyz proxy prida podporu noveho identity providera atp.

Na testingu job s nastavenym `authorization.app_proxy` prosel https://connection.eu-west-1.aws.keboola.dev/admin/projects/51/queue/2432809

Plus to same jsem hodil jeste do `job-configuration`, ktery se pripravil v ramci no-dind iniciativy https://github.com/keboola/job-queue/pull/377