### PR TITLE
PST-1242 Do not create empty `authorization.app_proxy.auth_rules[].allowed_roles` in config

### DIFF
--- a/Tests/Docker/Configuration/Authorization/AppProxyDefinitionTest.php
+++ b/Tests/Docker/Configuration/Authorization/AppProxyDefinitionTest.php
@@ -64,9 +64,16 @@ class AppProxyDefinitionTest extends TestCase
     /** @dataProvider provideValidAppProxyAuthorizationConfig */
     public function testValidAppProxyAuthorizationConfig(?array $config): void
     {
-        (new Processor())->processConfiguration(new AppProxyDefinition(), [
+        // process the user-provided config
+        $producedConfig = (new Processor())->processConfiguration(new AppProxyDefinition(), [
             'app_proxy' => $config,
         ]);
+
+        // process the config again to check that processing produces valid config
+        (new Processor())->processConfiguration(new AppProxyDefinition(), [
+            'app_proxy' => $producedConfig,
+        ]);
+
         self::assertTrue(true);
     }
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-1242
Followup na https://github.com/keboola/docker-bundle/pull/735

Pri testovani po releasu jsem jeste narazil, ze `allowed_roles` dela problem. V testech se to neprojevilo, protoze se to ukaze az kdyz se nechaji zvalidovat data, ktery validaci jednou prosly.