### PR TITLE
PST-1343: dataTypesConfiguration and processorConfiguration in Component definition

### DIFF
--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Keboola\DockerBundle\Tests\Docker;
 
-use InvalidArgumentException;
 use Keboola\DockerBundle\Docker\Component;
 use Keboola\DockerBundle\Exception\ApplicationException;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 class ComponentTest extends TestCase
 {
@@ -26,6 +24,12 @@ class ComponentTest extends TestCase
                 'forward_token' => true,
                 'forward_token_details' => true,
                 'default_bucket' => true,
+            ],
+            'dataTypesConfiguration' => [
+                'dateTypesSupport' => 'none',
+            ],
+            'processorConfiguration' => [
+                'allowedProcessorPosition' => 'any',
             ],
         ];
 

--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -26,7 +26,7 @@ class ComponentTest extends TestCase
                 'default_bucket' => true,
             ],
             'dataTypesConfiguration' => [
-                'dateTypesSupport' => 'none',
+                'dataTypesSupport' => 'none',
             ],
             'processorConfiguration' => [
                 'allowedProcessorPosition' => 'any',

--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -26,10 +26,10 @@ class ComponentTest extends TestCase
                 'default_bucket' => true,
             ],
             'dataTypesConfiguration' => [
-                'dataTypesSupport' => 'none',
+                'dataTypesSupport' => 'hints',
             ],
             'processorConfiguration' => [
-                'allowedProcessorPosition' => 'any',
+                'allowedProcessorPosition' => 'before',
             ],
         ];
 
@@ -55,8 +55,8 @@ class ComponentTest extends TestCase
         self::assertEquals(true, $component->forwardTokenDetails());
         self::assertEquals(true, $component->hasDefaultBucket());
         self::assertSame('master', $component->getImageTag());
-        self::assertSame(['dataTypesSupport' => 'none'], $component->getDataTypesConfiguration());
-        self::assertSame(['allowedProcessorPosition' => 'any'], $component->getProcessorConfiguration());
+        self::assertSame('hints', $component->getDataTypesSupport());
+        self::assertSame('before', $component->getAllowedProcessorPosition());
     }
 
     public function testConfigurationDefaults()
@@ -92,8 +92,8 @@ class ComponentTest extends TestCase
         self::assertEquals(false, $component->forwardToken());
         self::assertEquals(false, $component->forwardTokenDetails());
         self::assertEquals(false, $component->hasDefaultBucket());
-        self::assertSame([], $component->getDataTypesConfiguration());
-        self::assertSame([], $component->getProcessorConfiguration());
+        self::assertSame('none', $component->getDataTypesSupport());
+        self::assertSame('any', $component->getAllowedProcessorPosition());
     }
 
     public function testInvalidComponentNoDefinition()

--- a/Tests/Docker/ComponentTest.php
+++ b/Tests/Docker/ComponentTest.php
@@ -55,6 +55,8 @@ class ComponentTest extends TestCase
         self::assertEquals(true, $component->forwardTokenDetails());
         self::assertEquals(true, $component->hasDefaultBucket());
         self::assertSame('master', $component->getImageTag());
+        self::assertSame(['dataTypesSupport' => 'none'], $component->getDataTypesConfiguration());
+        self::assertSame(['allowedProcessorPosition' => 'any'], $component->getProcessorConfiguration());
     }
 
     public function testConfigurationDefaults()
@@ -90,6 +92,8 @@ class ComponentTest extends TestCase
         self::assertEquals(false, $component->forwardToken());
         self::assertEquals(false, $component->forwardTokenDetails());
         self::assertEquals(false, $component->hasDefaultBucket());
+        self::assertSame([], $component->getDataTypesConfiguration());
+        self::assertSame([], $component->getProcessorConfiguration());
     }
 
     public function testInvalidComponentNoDefinition()

--- a/Tests/Docker/Configuration/ImageConfigurationTest.php
+++ b/Tests/Docker/Configuration/ImageConfigurationTest.php
@@ -110,8 +110,6 @@ class ImageConfigurationTest extends TestCase
                 'gelf_server_type' => 'tcp',
                 'no_application_errors' => false,
             ],
-            'dataTypeSupport' => 'none',
-            'allowedProcessorPosition' => 'any',
         ];
         self::assertEquals($expectedConfiguration, $processedConfiguration);
     }
@@ -218,42 +216,6 @@ class ImageConfigurationTest extends TestCase
             'staging_storage' => [
                 'output' => 'whatever',
             ],
-        ];
-        (new Configuration\Component())->parse(['config' => $config]);
-    }
-
-    public function testWrongDataTypeSupport(): void
-    {
-        $this->expectException('\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
-        $this->expectExceptionMessage(
-            'The value "whatever" is not allowed for path "component.dataTypeSupport". ' .
-            'Permissible values: "authoritative", "hints", "none"',
-        );
-        $config = [
-            'definition' => [
-                'type' => 'dockerhub',
-                'uri' => 'keboola/docker-demo',
-            ],
-            'memory' => '64m',
-            'dataTypeSupport' => 'whatever',
-        ];
-        (new Configuration\Component())->parse(['config' => $config]);
-    }
-
-    public function testWrongAllowedProcessorPosition(): void
-    {
-        $this->expectException('\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException');
-        $this->expectExceptionMessage(
-            'The value "whatever" is not allowed for path "component.allowedProcessorPosition". ' .
-            'Permissible values: "any", "before", "after"',
-        );
-        $config = [
-            'definition' => [
-                'type' => 'dockerhub',
-                'uri' => 'keboola/docker-demo',
-            ],
-            'memory' => '64m',
-            'allowedProcessorPosition' => 'whatever',
         ];
         (new Configuration\Component())->parse(['config' => $config]);
     }

--- a/Tests/Docker/Configuration/ImageConfigurationTest.php
+++ b/Tests/Docker/Configuration/ImageConfigurationTest.php
@@ -26,7 +26,7 @@ class ImageConfigurationTest extends TestCase
                 'type' => 'gelf',
                 'verbosity' => [200 => 'verbose'],
                 'no_application_errors' => true,
-            ]
+            ],
         ];
         $expectedConfiguration = [
             'definition' => [

--- a/Tests/Docker/Configuration/ImageConfigurationTest.php
+++ b/Tests/Docker/Configuration/ImageConfigurationTest.php
@@ -26,9 +26,7 @@ class ImageConfigurationTest extends TestCase
                 'type' => 'gelf',
                 'verbosity' => [200 => 'verbose'],
                 'no_application_errors' => true,
-            ],
-            'dataTypeSupport' => 'hints',
-            'allowedProcessorPosition' => 'before',
+            ]
         ];
         $expectedConfiguration = [
             'definition' => [
@@ -58,8 +56,6 @@ class ImageConfigurationTest extends TestCase
                 'input' => 'local',
                 'output' => 'local',
             ],
-            'dataTypeSupport' => 'hints',
-            'allowedProcessorPosition' => 'before',
         ];
         $processedConfiguration = (new Configuration\Component())->parse(['config' => $config]);
         self::assertEquals($expectedConfiguration, $processedConfiguration);

--- a/src/Docker/Component.php
+++ b/src/Docker/Component.php
@@ -204,13 +204,13 @@ class Component
         return (bool) $this->data['logging']['no_application_errors'];
     }
 
-    public function getDataTypesConfiguration(): array
+    public function getDataTypesSupport(): string
     {
-        return $this->dataTypesConfiguration;
+        return $this->dataTypesConfiguration['dataTypesSupport'] ?? 'none';
     }
 
-    public function getProcessorConfiguration(): array
+    public function getAllowedProcessorPosition(): string
     {
-        return $this->processorConfiguration;
+        return $this->processorConfiguration['allowedProcessorPosition'] ?? 'any';
     }
 }

--- a/src/Docker/Component.php
+++ b/src/Docker/Component.php
@@ -15,6 +15,8 @@ class Component
     private array $data;
     private string $networkType;
     private array $features;
+    private array $dataTypesConfiguration;
+    private array $processorConfiguration;
 
     /**
      * Component constructor.
@@ -24,11 +26,11 @@ class Component
     {
         $this->id = empty($componentData['id']) ? '' : $componentData['id'];
         $data = empty($componentData['data']) ? [] : $componentData['data'];
-        if (isset($componentData['features'])) {
-            $this->features = $componentData['features'];
-        } else {
-            $this->features = [];
-        }
+
+        $this->features = $componentData['features'] ?? [];
+        $this->dataTypesConfiguration = $componentData['dataTypesConfiguration'] ?? [];
+        $this->processorConfiguration = $componentData['processorConfiguration'] ?? [];
+
         try {
             $this->data = (new Configuration\Component())->parse(['config' => $data]);
         } catch (InvalidConfigurationException $e) {
@@ -200,5 +202,15 @@ class Component
     public function isApplicationErrorDisabled(): bool
     {
         return (bool) $this->data['logging']['no_application_errors'];
+    }
+
+    public function getDataTypesConfiguration(): array
+    {
+        return $this->dataTypesConfiguration;
+    }
+
+    public function getProcessorConfiguration(): array
+    {
+        return $this->processorConfiguration;
     }
 }

--- a/src/Docker/Configuration/Component.php
+++ b/src/Docker/Configuration/Component.php
@@ -102,14 +102,6 @@ class Component extends Configuration
                     ->end()
                 ->end()
             ->end()
-            ->enumNode('dataTypeSupport')
-                ->values(['authoritative', 'hints', 'none'])
-                ->defaultValue('none')
-            ->end()
-            ->enumNode('allowedProcessorPosition')
-                ->values(['any', 'before', 'after'])
-                ->defaultValue('any')
-            ->end()
         ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-1343

- refactor (Component): use dataTypesConfiguration and processorConfiguration fields outside of data node


Validaci novejch fieldu pridame v ramci:
https://keboola.atlassian.net/browse/PST-1374