### PR TITLE
PST-1888 Do not fail job if state can't be stored after job because config does not exist

### DIFF
--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -147,10 +147,13 @@ class StateFile
                 $this->saveConfigurationState($configuration, $client);
             }
         } catch (ClientException $e) {
-            if ($e->getCode() === 404) {
-                throw new UserException('Failed to store state: ' . $e->getMessage(), $e);
+            if ($e->getCode() !== 404) {
+                throw $e;
             }
-            throw $e;
+
+            // we do not want to fail the job if config is not found
+            // sandboxes/apps do delete their config as a last step of delete job
+            $this->logger->warning('Failed to store state: ' . $e->getMessage());
         }
     }
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-1888

Pokud ukladani state failne na chybejicim configu, zalogujem to jen jako warn a nechame job dobehnout.

Dojit k tomu muze, pokud za behu jobu neco smazne konfiguraci, coz nove chceme delat schvalne (delete app/sandboxu). Pokud by si config smaznul user omylem, za behu jobu a pozdeji ho treba obnovil, state nebude ulozeny tak jako tak. Rozdil je jen v tom, ze user ten omyl nove nemusi poznat uz u jobu ktery bezi, ale az kdyby ho chtel pustit znovu.

Ozkouseno na testingu
![image](https://github.com/user-attachments/assets/8e02703d-ed27-4fc7-ac8e-9364d1eb78ce)
