### PR TITLE
Update `keboola/input-mapping` lib

### DIFF
--- a/Tests/Runner/RunnerTest.php
+++ b/Tests/Runner/RunnerTest.php
@@ -4144,14 +4144,10 @@ class RunnerTest extends BaseRunnerTest
         $inputTables = $outputs[0]->getInputTableResult()?->getTables();
         self::assertNotNull($inputTables);
 
-        /** @var TableInfo[] $inputTables */
-        $inputTables = iterator_to_array($inputTables);
         self::assertCount(1, $inputTables);
-
         self::assertSame('in.c-runner-test.test', $inputTables[0]->getId());
 
-        /** @var Column[] $columns */
-        $columns = iterator_to_array($inputTables[0]->getColumns());
+        $columns = $inputTables[0]->getColumns();
         self::assertCount(2, $columns);
 
         self::assertSame('id', $columns[0]->getName());

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "keboola/artifacts": "^3.1",
         "keboola/common-exceptions": "^1.0",
         "keboola/gelf-server": "^4.0",
-        "keboola/input-mapping": "^18.8",
+        "keboola/input-mapping": "^19.0.1",
         "keboola/oauth-v2-php-client": "^4.0",
         "keboola/object-encryptor": "^2.2",
         "keboola/output-mapping": "^24.17",


### PR DESCRIPTION
Potřebuju updatnout IM  (^19) v rámci `job-runner`, ale blokuje mě require `dockerbundle` lib, která má ^18 verzi.

https://keboola.atlassian.net/browse/PST-525