### PR TITLE
DataLoader - treat_values_as_null fixup for empty array

### DIFF
--- a/Tests/Docker/Configuration/ContainerConfigurationTest.php
+++ b/Tests/Docker/Configuration/ContainerConfigurationTest.php
@@ -929,7 +929,6 @@ class ContainerConfigurationTest extends TestCase
             'config' => [
                 'storage' => [
                     'output' => [
-                        'tables' => [],
                     ],
                 ],
             ],
@@ -945,14 +944,25 @@ class ContainerConfigurationTest extends TestCase
                             'first',
                             'second',
                         ],
-                        'tables' => [],
                     ],
                 ],
             ],
         ]);
-        self::assertEquals([
+        self::assertSame([
             'first',
             'second',
         ], $config['storage']['output']['treat_values_as_null']);
+
+        // empty array
+        $config = (new Configuration\Container())->parse([
+            'config' => [
+                'storage' => [
+                    'output' => [
+                        'treat_values_as_null' => [],
+                    ],
+                ],
+            ],
+        ]);
+        self::assertSame([], $config['storage']['output']['treat_values_as_null']);
     }
 }

--- a/Tests/Runner/DataLoaderTest.php
+++ b/Tests/Runner/DataLoaderTest.php
@@ -1877,4 +1877,118 @@ class DataLoaderTest extends BaseDataLoaderTest
             $data['rows'],
         );
     }
+
+    public function testTreatValuesAsNullDisable(): void
+    {
+        $fs = new Filesystem();
+        $fs->dumpFile(
+            $this->workingDir->getDataDir() . '/out/tables/data.csv',
+            '1,"",123',
+        );
+        $fs->dumpFile(
+            $this->workingDir->getDataDir() . '/out/tables/data.csv.manifest',
+            (string) json_encode([
+                'columns' => ['id', 'name', 'price'],
+            ]),
+        );
+        $component = new Component([
+            'id' => 'docker-demo',
+            'data' => [
+                'definition' => [
+                    'type' => 'dockerhub',
+                    'uri' => 'keboola/docker-demo',
+                    'tag' => 'master',
+                ],
+                'staging-storage' => [
+                    'input' => 'local',
+                    'output' => 'local',
+                ],
+            ],
+        ]);
+        $config = [
+            'storage' => [
+                'output' => [
+                    'treat_values_as_null' => [],
+                    'tables' => [
+                        [
+                            'source' => 'data.csv',
+                            'destination' => 'in.c-docker-demo-testConfig.treated-values-test',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $clientWrapper = new ClientWrapper(
+            new ClientOptions(
+                (string) getenv('STORAGE_API_URL'),
+                (string) getenv('STORAGE_API_TOKEN'),
+            ),
+        );
+
+        $this->clientWrapper->getBasicClient()->createBucket('docker-demo-testConfig', 'in');
+        $clientWrapper->getTableAndFileStorageClient()->createTableDefinition(
+            'in.c-docker-demo-testConfig',
+            [
+                'name' => 'treated-values-test',
+                'columns' => [
+                    [
+                        'name' => 'id',
+                        'basetype' => BaseType::INTEGER,
+                    ],
+                    [
+                        'name' => 'name',
+                        'basetype' => BaseType::STRING,
+                    ],
+                    [
+                        'name' => 'price',
+                        'basetype' => BaseType::INTEGER,
+                    ],
+                ],
+            ],
+        );
+
+        $dataLoader = new DataLoader(
+            $clientWrapper,
+            new NullLogger(),
+            $this->workingDir->getDataDir(),
+            new JobDefinition($config, $component),
+            new OutputFilter(10000),
+        );
+        $tableQueue = $dataLoader->storeOutput();
+        self::assertNotNull($tableQueue);
+        $tableQueue->waitForAll();
+
+        /** @var array|string $data */
+        $data = $clientWrapper->getTableAndFileStorageClient()->getTableDataPreview(
+            'in.c-docker-demo-testConfig.treated-values-test',
+            [
+                'format' => 'json',
+            ],
+        );
+
+        self::assertIsArray($data);
+        self::assertArrayHasKey('rows', $data);
+        self::assertSame(
+            [
+                [
+                    [
+                        'columnName' => 'id',
+                        'value' => '1',
+                        'isTruncated' => false,
+                    ],
+                    [
+                        'columnName' => 'name',
+                        'value' => '',
+                        'isTruncated' => false,
+                    ],
+                    [
+                        'columnName' => 'price',
+                        'value' => '123',
+                        'isTruncated' => false,
+                    ],
+                ],
+            ],
+            $data['rows'],
+        );
+    }
 }

--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -227,7 +227,7 @@ class DataLoader implements DataLoaderInterface
         }
 
         $treatValuesAsNull = $this->storageConfig['output']['treat_values_as_null'] ?? null;
-        if ($treatValuesAsNull) {
+        if ($treatValuesAsNull !== null) {
             $uploadTablesOptions['treat_values_as_null'] = $treatValuesAsNull;
         }
 
@@ -257,6 +257,7 @@ class DataLoader implements DataLoaderInterface
                 }
                 return null;
             }
+
             $tableWriter = new TableWriter($this->outputStrategyFactory);
             $tableWriter->setFormat($this->component->getConfigurationFormat());
             $tableQueue = $tableWriter->uploadTables(


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PST-1468

Before asking for review, check the following:

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task [PST-2298](https://keboola.atlassian.net/browse/PST-2298) under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918)


---

V OM je to ošetřené, ale tady mi zůstala chybka. Nefungovalo to s prázdným pole. Prázdné pole v nastavení nahrazování prázdného stringu za null vypíná.


[PST-2298]: https://keboola.atlassian.net/browse/PST-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ