### PR TITLE
DataLoader - ignore 404 ClientException on stagin provider cleanup

### DIFF
--- a/src/Docker/Runner/DataLoader/DataLoader.php
+++ b/src/Docker/Runner/DataLoader/DataLoader.php
@@ -459,6 +459,10 @@ class DataLoader implements DataLoaderInterface
                     $stagingProvider->cleanup();
                     $cleanedProviders[] = $stagingProvider;
                 } catch (ClientException $e) {
+                    if ($e->getCode() === 404) {
+                        // workspace is already deleted
+                        continue;
+                    }
                     // ignore errors if the cleanup fails because we a) can't fix it b) should not break the job
                     $this->logger->error('Failed to cleanup workspace: ' . $e->getMessage());
                 }


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PST-323

Before asking for review, check the following:

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task https://keboola.atlassian.net/browse/PST-2357 under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918)


---

`cleanWorkspace()` se může zavolat opakovaně, díky tomu se pak loguje `Workspace not found` i u běžného user erroru z transformace

Upravil jsem to, aby se logovaly jen chyby, ktere nejsou 404
