### PR TITLE
PST-2438 Allow extra root keys in state

### DIFF
--- a/Tests/Docker/Configuration/StateTest.php
+++ b/Tests/Docker/Configuration/StateTest.php
@@ -197,18 +197,32 @@ class StateTest extends TestCase
         (new Configuration\State())->parse(['state' => $state]);
     }
 
-    public function testExtraRootKey(): void
+    public function testDataAppRootKey(): void
     {
         $state = [
-            'invalidKey' => 'invalidValue',
-            'component' => [
+            StateFile::NAMESPACE_DATA_APP => [
+                'key' => 'foo',
+            ],
+        ];
+        $expected = [
+            StateFile::NAMESPACE_COMPONENT => [],
+            StateFile::NAMESPACE_DATA_APP => [
                 'key' => 'foo',
             ],
         ];
 
-        (new Configuration\State())->parse(['state' => $state]);
-
         $processed = (new Configuration\State())->parse(['state' => $state]);
-        self::assertEquals($state, $processed);
+        self::assertEquals($expected, $processed);
+    }
+
+    public function testInvalidRootKey(): void
+    {
+        $state = [
+            'invalidKey' => 'invalidValue',
+        ];
+
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('Unrecognized option "invalidKey" under "state"');
+        (new Configuration\State())->parse(['state' => $state]);
     }
 }

--- a/Tests/Docker/Configuration/StateTest.php
+++ b/Tests/Docker/Configuration/StateTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class StateTest extends TestCase
 {
-    public function testEmptyState()
+    public function testEmptyState(): void
     {
         $state = [];
         $expected = [
@@ -21,7 +21,7 @@ class StateTest extends TestCase
         self::assertEquals($expected, $processed);
     }
 
-    public function testComponentState()
+    public function testComponentState(): void
     {
         $state = [
             StateFile::NAMESPACE_COMPONENT => ['key' => 'foo'],
@@ -33,7 +33,7 @@ class StateTest extends TestCase
         self::assertEquals($expected, $processed);
     }
 
-    public function testStorageInputTablesState()
+    public function testStorageInputTablesState(): void
     {
         $state = [
             StateFile::NAMESPACE_STORAGE => [
@@ -65,7 +65,7 @@ class StateTest extends TestCase
         self::assertEquals($expected, $processed);
     }
 
-    public function testStorageInputTablesStateExtraKey()
+    public function testStorageInputTablesStateExtraKey(): void
     {
         $state = [
             StateFile::NAMESPACE_STORAGE => [
@@ -86,7 +86,7 @@ class StateTest extends TestCase
         (new Configuration\State())->parse(['state' => $state]);
     }
 
-    public function testStorageInputTablesStateMissingKey()
+    public function testStorageInputTablesStateMissingKey(): void
     {
         $state = [
             StateFile::NAMESPACE_STORAGE => [
@@ -107,7 +107,7 @@ class StateTest extends TestCase
         (new Configuration\State())->parse(['state' => $state]);
     }
 
-    public function testStorageInputFilesState()
+    public function testStorageInputFilesState(): void
     {
         $state = [
             StateFile::NAMESPACE_STORAGE => [
@@ -147,7 +147,7 @@ class StateTest extends TestCase
         self::assertEquals($expected, $processed);
     }
 
-    public function testStorageInputFilesStateExtraKey()
+    public function testStorageInputFilesStateExtraKey(): void
     {
         $state = [
             StateFile::NAMESPACE_STORAGE => [
@@ -172,7 +172,7 @@ class StateTest extends TestCase
         (new Configuration\State())->parse(['state' => $state]);
     }
 
-    public function testStorageInputFilesStateMissingKey()
+    public function testStorageInputFilesStateMissingKey(): void
     {
         $state = [
             StateFile::NAMESPACE_STORAGE => [
@@ -197,14 +197,18 @@ class StateTest extends TestCase
         (new Configuration\State())->parse(['state' => $state]);
     }
 
-    public function testInvalidRootKey()
+    public function testExtraRootKey(): void
     {
         $state = [
             'invalidKey' => 'invalidValue',
+            'component' => [
+                'key' => 'foo',
+            ],
         ];
 
-        self::expectException(InvalidConfigurationException::class);
-        self::expectExceptionMessage('Unrecognized option "invalidKey" under "state"');
         (new Configuration\State())->parse(['state' => $state]);
+
+        $processed = (new Configuration\State())->parse(['state' => $state]);
+        self::assertEquals($state, $processed);
     }
 }

--- a/Tests/Runner/DataLoaderTest.php
+++ b/Tests/Runner/DataLoaderTest.php
@@ -675,7 +675,7 @@ class DataLoaderTest extends BaseDataLoaderTest
                                     'name' => 'int',
                                     'data_type' => [
                                         'base' => [
-                                            'type' => BaseType::NUMERIC,
+                                            'type' => BaseType::INTEGER,
                                         ],
                                     ],
                                     'primary_key' => true,
@@ -755,7 +755,9 @@ class DataLoaderTest extends BaseDataLoaderTest
         self::assertNotNull($tableQueue);
         $tableQueue->waitForAll();
 
-        $tableDetails = $clientWrapper->getBasicClient()->getTable('in.c-docker-demo-testConfig.fixed-type-test');
+        $tableDetails = $clientWrapper->getBasicClient()->getTable(
+            'in.c-docker-demo-testConfig.authoritative-types-test',
+        );
         self::assertTrue($tableDetails['isTyped']);
 
         $tableDefinitionColumns = $tableDetails['definition']['columns'];
@@ -807,7 +809,7 @@ class DataLoaderTest extends BaseDataLoaderTest
                                     'name' => 'int',
                                     'data_type' => [
                                         'base' => [
-                                            'type' => BaseType::NUMERIC,
+                                            'type' => BaseType::INTEGER,
                                         ],
                                     ],
                                     'primary_key' => true,
@@ -842,7 +844,13 @@ class DataLoaderTest extends BaseDataLoaderTest
                 (string) getenv('STORAGE_API_TOKEN_FEATURE_NEW_NATIVE_TYPES'),
             ),
         );
-        $clientWrapper->getBasicClient()->dropTable($tableId);
+        try {
+            $clientWrapper->getBasicClient()->dropTable($tableId);
+        } catch (ClientException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+        }
 
         $dataLoader = new DataLoader(
             $clientWrapper,
@@ -879,7 +887,7 @@ class DataLoaderTest extends BaseDataLoaderTest
 
         self::assertCount(2, $intColumnMetadata);
         self::assertEquals([
-            ['key' => 'KBC.datatype.basetype', 'value' => 'NUMERIC', 'provider' => 'docker-demo'],
+            ['key' => 'KBC.datatype.basetype', 'value' => 'INTEGER', 'provider' => 'docker-demo'],
             ['key' => 'KBC.datatype.nullable', 'value' => '1', 'provider' => 'docker-demo'],
         ], array_map(function ($v) {
             unset($v['id'], $v['timestamp']);
@@ -966,7 +974,7 @@ class DataLoaderTest extends BaseDataLoaderTest
                                     'name' => 'int',
                                     'data_type' => [
                                         'base' => [
-                                            'type' => BaseType::NUMERIC,
+                                            'type' => BaseType::INTEGER,
                                         ],
                                     ],
                                     'primary_key' => true,

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -8,7 +8,6 @@ use Generator;
 use Keboola\DockerBundle\Docker\JobScopedEncryptor;
 use Keboola\DockerBundle\Docker\OutputFilter\NullFilter;
 use Keboola\DockerBundle\Docker\Runner\StateFile;
-use Keboola\DockerBundle\Exception\UserException;
 use Keboola\DockerBundle\Tests\TestEnvVarsTrait;
 use Keboola\InputMapping\State\InputFileStateList;
 use Keboola\InputMapping\State\InputTableStateList;
@@ -869,6 +868,32 @@ class StateFileTest extends TestCase
             'json',
             'my-component',
             'config-id',
+            new NullFilter(),
+            $testLogger,
+            'row-id',
+        );
+        $stateFile->stashState($state);
+        $stateFile->persistState(new InputTableStateList([]), new InputFileStateList([]));
+    }
+
+    public function testStateIsNotPersistedWhenConfigIdIsNotSet(): void
+    {
+        $sapiStub = $this->createPartialMock(Client::class, ['apiPutJson']);
+        $sapiStub->expects(self::never())->method('apiPutJson');
+
+        $state = ['key' => 'fooBar'];
+        $testLogger = new TestLogger();
+        $clientWrapper = $this->createMock(ClientWrapper::class);
+        $clientWrapper->method('getBasicClient')->willReturn($sapiStub);
+
+        $stateFile = new StateFile(
+            $this->dataDir,
+            $clientWrapper,
+            $this->getJobScopedEncryptor(),
+            [StateFile::NAMESPACE_COMPONENT => $state],
+            'json',
+            'my-component',
+            null,
             new NullFilter(),
             $testLogger,
             'row-id',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -791,51 +791,6 @@ parameters:
 			path: Tests/Docker/Configuration/SharedCodeRowConfigurationTest.php
 
 		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testComponentState\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testEmptyState\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testInvalidRootKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testStorageInputFilesState\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testStorageInputFilesStateExtraKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testStorageInputFilesStateMissingKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testStorageInputTablesState\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testStorageInputTablesStateExtraKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
-			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Configuration\\\\StateTest\\:\\:testStorageInputTablesStateMissingKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: Tests/Docker/Configuration/StateTest.php
-
-		-
 			message: "#^Method Keboola\\\\DockerBundle\\\\Tests\\\\Docker\\\\Container\\\\ContainerErrorHandlingTest\\:\\:testEnvironmentPassing\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: Tests/Docker/Container/ContainerErrorHandlingTest.php

--- a/src/Docker/Configuration/State.php
+++ b/src/Docker/Configuration/State.php
@@ -14,6 +14,7 @@ class State extends Configuration
     {
         $treeBuilder = new TreeBuilder('state');
         $root = $treeBuilder->getRootNode();
+        $root->ignoreExtraKeys(false);
         $root->children()
             ->arrayNode(StateFile::NAMESPACE_COMPONENT)->prototype('variable')->end()->end()
             ->arrayNode(StateFile::NAMESPACE_STORAGE)

--- a/src/Docker/Configuration/State.php
+++ b/src/Docker/Configuration/State.php
@@ -14,7 +14,6 @@ class State extends Configuration
     {
         $treeBuilder = new TreeBuilder('state');
         $root = $treeBuilder->getRootNode();
-        $root->ignoreExtraKeys(false);
         $root->children()
             ->arrayNode(StateFile::NAMESPACE_COMPONENT)->prototype('variable')->end()->end()
             ->arrayNode(StateFile::NAMESPACE_STORAGE)
@@ -47,6 +46,9 @@ class State extends Configuration
                         ->end()
                     ->end()
                 ->end()
+            ->end()
+            ->arrayNode(StateFile::NAMESPACE_DATA_APP)
+                ->ignoreExtraKeys(false)
             ->end()
         ->end();
         return $treeBuilder;

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -110,6 +110,11 @@ class StateFile
         InputTableStateList $inputTableStateList,
         InputFileStateList $inputFileStateList,
     ): void {
+        $configurationId = $this->configurationId;
+        if (!$configurationId) {
+            return;
+        }
+
         $this->outputFilter->collectValues((array) $this->currentState);
 
         if ($this->clientWrapper->isDevelopmentBranch()) {
@@ -120,7 +125,7 @@ class StateFile
 
         $configuration = new Configuration();
         $configuration->setComponentId($this->componentId);
-        $configuration->setConfigurationId($this->configurationId);
+        $configuration->setConfigurationId($configurationId);
         try {
             if ($this->currentState !== null) {
                 $encryptedStateData = $this->encryptor->encrypt($this->currentState);
@@ -142,14 +147,14 @@ class StateFile
             if ($this->configurationRowId) {
                 $storedState = $this->loadConfigurationRowState(
                     $this->componentId,
-                    $this->configurationId,
+                    $configurationId,
                     $this->configurationRowId,
                     $client,
                 );
             } else {
                 $storedState = $this->loadConfigurationState(
                     $this->componentId,
-                    $this->configurationId,
+                    $configurationId,
                     $client,
                 );
             }

--- a/src/Docker/Runner/StateFile.php
+++ b/src/Docker/Runner/StateFile.php
@@ -31,6 +31,7 @@ class StateFile
     public const NAMESPACE_INPUT = 'input';
     public const NAMESPACE_TABLES = 'tables';
     public const NAMESPACE_FILES = 'files';
+    public const NAMESPACE_DATA_APP = 'data_app';
 
     private string $dataDirectory;
     private ClientWrapper $clientWrapper;


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2438

Povoleni dalsich root klicu mimo `component` a `storage` ve state konfigurace. Job Runner prepisuje jen puvodni `component` a `storage`. Zbytek state nechava byt. (puvodne to premlasklo cely state ve storage).

Jelikoz se state cte ze storage, upravi a pak zase cely zapise, muze se teoreticky stat, ze neco jineho upravit state v mezicase a runner pak tu zmenu zase prepise zpatky.

Ozkouseno s data appkou na testingu.