### PR TITLE
PAT-404 Update SAPI client (main branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "keboola/php-temp": "^2.0",
         "keboola/php-utils": "^5.0",
         "keboola/staging-provider": "^10.0.1",
-        "keboola/storage-api-client": "^18.1",
+        "keboola/storage-api-client": "^18.2.3",
         "keboola/storage-api-php-client-branch-wrapper": "^6.0",
         "monolog/monolog": "^2.5",
         "mustache/mustache": "^2.13",


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PAT-404

Update na latest `keboola/storage-api-client:^18.2.3`, ktery ma vyreseny prechod na stringovy ID event.