### PR TITLE
chore: AJDA-370 bump output mapping to 27.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "keboola/common-exceptions": "^1.0",
         "keboola/gelf-server": "^4.0",
         "keboola/input-mapping": "^21.0",
-        "keboola/job-queue-job-configuration": "^2.0",
+        "keboola/job-queue-job-configuration": "^2.1",
         "keboola/oauth-v2-php-client": "^4.0",
         "keboola/object-encryptor": "^2.2",
         "keboola/output-mapping": "^27.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "keboola/job-queue-job-configuration": "^2.0",
         "keboola/oauth-v2-php-client": "^4.0",
         "keboola/object-encryptor": "^2.2",
-        "keboola/output-mapping": "^26.0",
+        "keboola/output-mapping": "^27.0",
         "keboola/php-temp": "^2.0",
         "keboola/php-utils": "^5.0",
         "keboola/staging-provider": "^12.0",


### PR DESCRIPTION
Jira: [AJDA-370](https://keboola.atlassian.net/browse/AJDA-370)

Connected to https://github.com/keboola/platform-libraries/pull/402


[AJDA-370]: https://keboola.atlassian.net/browse/AJDA-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ