### PR TITLE
fix docker image version to bookworm

### DIFF
--- a/DockerfileTests
+++ b/DockerfileTests
@@ -2,7 +2,7 @@ ARG APP_USER_NAME=app
 ARG APP_USER_UID=1000
 ARG APP_USER_GID=1000
 
-FROM php:8.2-cli
+FROM php:8.2-cli-bookworm
 ENV DEBIAN_FRONTEND noninteractive
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_FLAGS="--prefer-dist --no-interaction"


### PR DESCRIPTION
Jira: PST-XXX

Before asking for review, check the following:

- [ ] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task [PST-XXX] under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918)


---

**Release Notes**
- fix lock version for docker image to bookworm

**Plans for customer communication**
- none

**Impact analysis**
- it should be same image already used, but new debian was released

**Change type**
- fix

**Justification**
- Service wont build

**Deployment**
- Review & Release

**Rollback plan**
- Rollback & deploy

**Post release support plan**
- none