### PR TITLE
PAT-1529: Apply fallback for components with undefined `definition.name`

### DIFF
--- a/Tests/Docker/Image/ReplicatedRegistryImageTest.php
+++ b/Tests/Docker/Image/ReplicatedRegistryImageTest.php
@@ -7,8 +7,8 @@ namespace Keboola\DockerBundle\Tests\Docker\Image;
 use Keboola\DockerBundle\Docker\Image\ReplicatedRegistry;
 use Keboola\DockerBundle\Docker\Image\ReplicatedRegistryImage;
 use Keboola\JobQueue\JobConfiguration\JobDefinition\Component\ComponentSpecification;
-use LogicException;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 class ReplicatedRegistryImageTest extends TestCase
@@ -93,7 +93,7 @@ class ReplicatedRegistryImageTest extends TestCase
         );
     }
 
-    public function testGetImageIdThrowsWhenDefinitionNameMissing(): void
+    public function testGetImageIdFallsBackToUriTransformationWhenDefinitionNameMissing(): void
     {
         $imageConfig = new ComponentSpecification([
             'data' => [
@@ -111,15 +111,22 @@ class ReplicatedRegistryImageTest extends TestCase
             'testpass',
         );
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(self::stringContains($imageConfig->getId()));
+
         $image = new ReplicatedRegistryImage(
             $imageConfig,
-            new NullLogger(),
+            $logger,
             $service,
         );
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('definition.name required for replicated registry');
+        $result = $image->getImageId();
 
-        $image->getImageId();
+        self::assertSame(
+            'us-docker.pkg.dev/my-project/my-repo/keboola/test-component',
+            $result,
+        );
     }
 }

--- a/Tests/Docker/Image/ReplicatedRegistryTest.php
+++ b/Tests/Docker/Image/ReplicatedRegistryTest.php
@@ -116,6 +116,90 @@ class ReplicatedRegistryTest extends TestCase
         ];
     }
 
+    /** @dataProvider transformImageUrlDataProvider */
+    public function testTransformImageUrl(
+        string $replicatedRegistryUrl,
+        string $originalUrl,
+        string $expectedUrl,
+    ): void {
+        $service = new ReplicatedRegistry(
+            true,
+            $replicatedRegistryUrl,
+            'testuser',
+            'testpass',
+        );
+
+        self::assertSame($expectedUrl, $service->transformImageUrl($originalUrl));
+    }
+
+    public static function transformImageUrlDataProvider(): iterable
+    {
+        yield 'ECR to GAR with tag' => [
+            'replicatedRegistryUrl' => 'registry.example.com/keboola',
+            'originalUrl' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/component:1.0.0',
+            'expectedUrl' => 'registry.example.com/keboola/developer-portal-v2/component:1.0.0',
+        ];
+        yield 'ECR to GAR without tag' => [
+            'replicatedRegistryUrl' => 'registry.example.com/keboola',
+            'originalUrl' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/component',
+            'expectedUrl' => 'registry.example.com/keboola/developer-portal-v2/component',
+        ];
+        yield 'ECR to GAR with digest' => [
+            'replicatedRegistryUrl' => 'registry.example.com/keboola',
+            'originalUrl' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/component@sha256:abcd1234',
+            'expectedUrl' => 'registry.example.com/keboola/component@sha256:abcd1234',
+        ];
+        yield 'non-ECR image unchanged' => [
+            'replicatedRegistryUrl' => 'registry.example.com/keboola',
+            'originalUrl' => 'docker.io/library/nginx:latest',
+            'expectedUrl' => 'docker.io/library/nginx:latest',
+        ];
+        yield 'ECR to ACR' => [
+            'replicatedRegistryUrl' => 'myregistry.azurecr.io',
+            'originalUrl' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/component:v1',
+            'expectedUrl' => 'myregistry.azurecr.io/component:v1',
+        ];
+        yield 'ECR to GAR with port' => [
+            'replicatedRegistryUrl' => 'registry.example.com:5000/keboola',
+            'originalUrl' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/component:latest',
+            'expectedUrl' => 'registry.example.com:5000/keboola/component:latest',
+        ];
+        yield 'ECR to GAR with multiple path segments' => [
+            'replicatedRegistryUrl' => 'registry.example.com/org/team/keboola',
+            'originalUrl' => '147946154733.dkr.ecr.us-east-1.amazonaws.com/component:v1.0.0',
+            'expectedUrl' => 'registry.example.com/org/team/keboola/component:v1.0.0',
+        ];
+    }
+
+    /** @dataProvider transformImageUrlWhenDisabledDataProvider */
+    public function testTransformImageUrlWhenDisabledThrowsException(
+        bool $useReplicatedRegistry,
+        string $replicatedRegistryUrl,
+    ): void {
+        $service = new ReplicatedRegistry($useReplicatedRegistry, $replicatedRegistryUrl, 'testuser', 'testpass');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Replicated registry is not enabled');
+
+        $service->transformImageUrl('147946154733.dkr.ecr.us-east-1.amazonaws.com/component:v1');
+    }
+
+    public static function transformImageUrlWhenDisabledDataProvider(): iterable
+    {
+        yield 'disabled with empty URL' => [
+            'useReplicatedRegistry' => false,
+            'replicatedRegistryUrl' => '',
+        ];
+        yield 'disabled with non-empty URL' => [
+            'useReplicatedRegistry' => false,
+            'replicatedRegistryUrl' => 'registry.example.com/keboola',
+        ];
+        yield 'enabled with empty URL' => [
+            'useReplicatedRegistry' => true,
+            'replicatedRegistryUrl' => '',
+        ];
+    }
+
     /** @dataProvider loginParamsDataProvider */
     public function testGetLoginParams(
         string $registryUrl,

--- a/src/Docker/Image/ReplicatedRegistry.php
+++ b/src/Docker/Image/ReplicatedRegistry.php
@@ -9,6 +9,8 @@ use SensitiveParameter;
 
 class ReplicatedRegistry
 {
+    private const ECR_REGISTRY_URL = '147946154733.dkr.ecr.us-east-1.amazonaws.com';
+
     public function __construct(
         private readonly bool $useReplicatedRegistry,
         private string $replicatedRegistryUrl,
@@ -30,6 +32,14 @@ class ReplicatedRegistry
             throw new LogicException('Replicated registry is not enabled');
         }
         return $this->replicatedRegistryUrl . '/' . $imageName;
+    }
+
+    public function transformImageUrl(string $originalImageId): string
+    {
+        if (!$this->isEnabled()) {
+            throw new LogicException('Replicated registry is not enabled');
+        }
+        return str_replace(self::ECR_REGISTRY_URL, $this->replicatedRegistryUrl, $originalImageId);
     }
 
     public function getLoginParams(): string

--- a/src/Docker/Image/ReplicatedRegistryImage.php
+++ b/src/Docker/Image/ReplicatedRegistryImage.php
@@ -8,7 +8,6 @@ use Keboola\DockerBundle\Docker\Image;
 use Keboola\DockerBundle\Exception\ApplicationException;
 use Keboola\DockerBundle\Exception\LoginFailedException;
 use Keboola\JobQueue\JobConfiguration\JobDefinition\Component\ComponentSpecification;
-use LogicException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\Process;
 use Throwable;
@@ -27,10 +26,11 @@ class ReplicatedRegistryImage extends Image
     {
         $imageName = $this->getSourceComponent()->getImageName();
         if ($imageName === null) {
-            throw new LogicException(sprintf(
-                'Component "%s" is missing definition.name required for replicated registry.',
+            $this->logger->warning(sprintf(
+                'Component "%s" is missing definition.name, falling back to URI-based registry transformation.',
                 $this->getSourceComponent()->getId(),
             ));
+            return $this->replicatedRegistry->transformImageUrl($this->imageId);
         }
         return $this->replicatedRegistry->composeImageUrl($imageName);
     }


### PR DESCRIPTION
Fix for https://github.com/keboola/docker-bundle/pull/800
---

https://linear.app/keboola/issue/PAT-1529/job-runner-compose-image-uri-with-fallback

## Description
Image URI composition with awareness of replicated registries was introduced in https://github.com/keboola/docker-bundle/pull/800. Unfortunately, strict `definition.name` validation caused an [incident](https://keboolaglobal.slack.com/archives/C0AJ4CFS961) for several components on the `europe-west3` stack.

For now — until we determinate how to properly handle the non-synced components — we've decided to handle components without `definition.name` by falling back to the ECR base URI replacement and logging a warning.

## Release Notes
- **Justification**
   We need to mitigate the strict behavior introduced in https://github.com/keboola/docker-bundle/pull/800: if `definition.name` is undefined, we use [the old-way URI resolving](https://github.com/keboola/docker-bundle/pull/801/changes#diff-e89e260b9ddaae933bee616c3f6fb320ca0cb8a1b15338c7954bf7851a13d47aR37) and log a warning.

- **Plans for Customer Communication**
   None.

- **Impact Analysis**
   This modification should have no impact, as undefined `definition.name` values are handled via the fallback mechanism.

- **Deployment Plan**
   Merge.

- **Rollback Plan**
   Revert this PR.

- **Post-Release Support Plan**
   Monitor job-runner in DD.