### PR TITLE
bump input mapping version

### DIFF
--- a/Tests/Docker/Configuration/ConfigurationAdapterTest.php
+++ b/Tests/Docker/Configuration/ConfigurationAdapterTest.php
@@ -31,7 +31,6 @@ class ConfigurationAdapterTest extends TestCase
                             'where_operator' => 'eq',
                             'column_types' => [],
                             'overwrite' => false,
-                            'use_view' => false,
                             'keep_internal_timestamp_column' => true,
                         ],
                     ],
@@ -75,7 +74,6 @@ storage:
                 where_operator: eq
                 column_types: {  }
                 overwrite: false
-                use_view: false
                 keep_internal_timestamp_column: true
         files: {  }
 parameters:
@@ -113,7 +111,6 @@ EOT;
                     "where_operator": "eq",
                     "column_types": [],
                     "overwrite": false,
-                    "use_view": false,
                     "keep_internal_timestamp_column": true
                 }
             ],

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-zip": "*",
         "keboola/common-exceptions": "^1.0",
         "keboola/gelf-server": "^4.0",
-        "keboola/input-mapping": "^22.0",
+        "keboola/input-mapping": "^23.0",
         "keboola/job-queue-artifacts": "^4.0",
         "keboola/job-queue-job-configuration": "^3.5.1",
         "keboola/oauth-v2-php-client": "^5.0",


### PR DESCRIPTION
[link to issue](https://linear.app/keboola/issue/AJDA-2820/update-job-runner)

No-DIND counterpart: [keboola/job-queue#716](https://github.com/keboola/job-queue/pull/716)

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918) — handled in [keboola/job-queue#716](https://github.com/keboola/job-queue/pull/716).

---

## Description

Bumps `keboola/input-mapping` from `^22.0` to the released `^23.0`. In v23 workspace table loads go through the Storage API `workspaces/{id}/input-mapping-load` endpoint and the per-table load-type decision (CLONE / VIEW / COPY) is resolved server-side by Connection; the client-side decider (`LoadTypeDecider`, `WorkspaceLoadPlan`, …) is removed from the library — see [keboola/platform-libraries#511](https://github.com/keboola/platform-libraries/pull/511) and the [v23.0.0 release notes](https://github.com/keboola/input-mapping/releases/tag/23.0.0).

No application code changes are required: docker-bundle drives loading through the unchanged `Reader::prepareAndExecuteTableLoads` API, so the only change here is the constraint bump in `composer.json`.

## Justification

Adopt the input-mapping changes from AJDA-2841 (BigQuery Parity, parent AJDA-2817) now that they are released, so the job runner picks up the new server-side load-type resolution.

## Plans for Customer Communication

None.

## Impact Analysis

No application code changed. Load-type decisions (CLONE/VIEW/COPY) move server-side, so they can differ from the old client-side decider where feature gating diverges (`bq-enable-clone`, `input-mapping-read-only-storage`). Not gated by a feature flag. Affects all stacks, including single-tenants.

## Deployment Plan

Standard CI/CD — the image is published from the merge commit and ArgoCD picks it up.

## Rollback Plan

Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan

None.
