### PR TITLE
ci: free disk space before Runner Tests to avoid Docker pull failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,15 @@ stages:
         timeoutInMinutes: 100
         steps:
           - script: |
+              echo '=== disk usage before cleanup ==='
+              df -h /
+              sudo du -sh /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache 2>/dev/null | sort -h || true
+              sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+              docker system prune -af || true
+              echo '=== disk usage after cleanup ==='
+              df -h /
+            displayName: 'Free disk space'
+          - script: |
               docker compose build --pull
               docker compose run tests ./vendor/bin/phpunit --testsuite runner-tests
             env:


### PR DESCRIPTION
## Summary

The **Runner Tests** job runs on a Microsoft-hosted `ubuntu-latest` agent and pulls many large component images during the suite. That exhausts `/var/lib/docker` and the job fails intermittently with:

```
Cannot pull image '…keboola.snowflake-transformation:1.5.0':
write /var/lib/docker/tmp/GetImageBlob…: no space left on device
```

This is not a test failure — it's the agent running out of disk mid-run.

### Fix

Add a `Free disk space` step at the start of the `runnerTests` job that reclaims the OS disk (where `/var/lib/docker` lives) by removing the large **preinstalled** toolsets the agent image ships but this repo never uses — .NET (`/usr/share/dotnet`), Android SDK (`/usr/local/lib/android`), Haskell (`/opt/ghc`, `/usr/local/.ghcup`) and CodeQL (`/opt/hostedtoolcache/CodeQL`) — and runs `docker system prune -af`. It prints `df -h` and a `du` breakdown before/after so we can see actual numbers and tune later.

Scoped to `runnerTests` (the job that fails). If the same wall is hit by other hosted-agent jobs (e.g. the storage-backend suites) the same step can be added there; if freeing the OS disk turns out to be insufficient, the fallback is relocating Docker's `data-root` to a larger mounted volume.

Unblocks CI for #805 (AJDA-3007).

## Release Notes
- **Justification**
    - CI-only change. The Runner Tests job intermittently fails because the hosted build agent runs out of disk while pulling component images; this frees agent disk so the suite can complete. No product/runtime code is touched.

- **Plans for Customer Communication**
    - None. Internal CI change, no customer-facing impact.

- **Impact Analysis**
    - Affects only the CI pipeline (`azure-pipelines.yml`), the `runnerTests` job. The removed directories are unused preinstalled toolsets on the ephemeral agent; deletion is scoped to the agent VM for that run. No impact on tenants or runtime behavior.

- **Deployment Plan**
    - Merge to `main`; applies to subsequent pipeline runs. No deployment.

- **Rollback Plan**
    - Fully reversible — revert the commit.

- **Post-Release Support Plan**
    - None. Watch the next Runner Tests run; the before/after `df -h` output confirms how much space is reclaimed.
