### PR TITLE
fix: Use escapeshellarg() for container environment variables

### DIFF
--- a/Tests/Docker/Container/ContainerTest.php
+++ b/Tests/Docker/Container/ContainerTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Keboola\DockerBundle\Tests\Docker\Container;
 
+use Keboola\DockerBundle\Docker\Container;
 use Keboola\DockerBundle\Docker\RunCommandOptions;
 use Keboola\DockerBundle\Tests\BaseContainerTest;
+use Symfony\Component\Process\Process;
 
 class ContainerTest extends BaseContainerTest
 {
+    // phpcs:ignore Generic.Files.LineLength.MaxExceeded
+    private const IMAGE_ID = '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/keboola.python-transformation:1.4.0';
+
     public function testRunCommandWithContainerRootUserFeature()
     {
         $runCommandOptions = new RunCommandOptions(
@@ -29,14 +34,118 @@ class ContainerTest extends BaseContainerTest
             . " --memory '256M'"
             . " --net 'bridge'"
             . " --cpus '2'"
-            . ' --env "var=val"'
-            . ' --env "příliš=žluťoučký"'
-            . " --env \"var2=weird = '\\\"value\""
+            . " --env 'var=val'"
+            . " --env 'příliš=žluťoučký'"
+            . " --env 'var2=weird = '\\''\"value'"
             . " --label 'com.keboola.runner.jobId=12345678'"
             . " --label 'com.keboola.runner.runId=10.20.30'"
             . " --name 'name'"
-            . " '147946154733.dkr.ecr.us-east-1.amazonaws.com/developer-portal-v2/keboola.python-transformation:1.4.0'";
+            . " '" . self::IMAGE_ID . "'";
         self::assertEquals($expected, $container->getRunCommand('name'));
+    }
+
+    /**
+     * @dataProvider provideShellInjectionEnvironmentVariables
+     */
+    public function testRunCommandEscapesEnvironmentVariables(string $value, string $expectedArgument): void
+    {
+        $container = $this->getContainerWithEnvironmentVariables(['KBC_CONFIGID' => $value]);
+
+        self::assertStringContainsString(
+            ' --env ' . $expectedArgument . " --name 'name'",
+            $container->getRunCommand('name'),
+        );
+    }
+
+    /**
+     * The run command is handed to `/bin/sh -c` via Process::fromShellCommandline(), so the only thing that
+     * matters is what the shell parses it into: every environment variable must come out as a single argument
+     * holding the original value verbatim, with nothing substituted and no extra command appended.
+     *
+     * @dataProvider provideShellInjectionEnvironmentVariables
+     */
+    public function testEnvironmentVariablesReachTheShellVerbatim(string $value): void
+    {
+        $container = $this->getContainerWithEnvironmentVariables(['KBC_CONFIGID' => $value]);
+
+        self::assertSame(
+            [
+                '--volume', $this->getTempDir() . '/data:/data',
+                '--volume', $this->getTempDir() . '/tmp:/tmp',
+                '--memory', '256M',
+                '--net', 'bridge',
+                '--cpus', '2',
+                '--env', 'KBC_CONFIGID=' . $value,
+                '--name', 'name',
+                self::IMAGE_ID,
+            ],
+            $this->parseCommandArguments($container->getRunCommand('name')),
+        );
+    }
+
+    public function provideShellInjectionEnvironmentVariables(): iterable
+    {
+        yield 'command substitution' => [
+            'value' => 'x$(id -un)y',
+            'expectedArgument' => "'KBC_CONFIGID=x\$(id -un)y'",
+        ];
+        yield 'backticks' => [
+            'value' => 'x`id -un`y',
+            'expectedArgument' => "'KBC_CONFIGID=x`id -un`y'",
+        ];
+        yield 'escaped quote breaking out of the double-quoted string' => [
+            'value' => 'a\";id;#',
+            'expectedArgument' => "'KBC_CONFIGID=a\\\";id;#'",
+        ];
+        yield 'trailing backslash' => [
+            'value' => 'a\\',
+            'expectedArgument' => "'KBC_CONFIGID=a\\'",
+        ];
+        yield 'single quote' => [
+            'value' => "a';id;#",
+            'expectedArgument' => "'KBC_CONFIGID=a'\\'';id;#'",
+        ];
+        yield 'newline' => [
+            'value' => "a\nid",
+            'expectedArgument' => "'KBC_CONFIGID=a\nid'",
+        ];
+        yield 'variable expansion' => [
+            'value' => 'a$HOME',
+            'expectedArgument' => "'KBC_CONFIGID=a\$HOME'",
+        ];
+    }
+
+    private function getContainerWithEnvironmentVariables(array $environmentVariables): Container
+    {
+        $imageConfiguration = $this->getImageConfiguration();
+        // avoids the intentional `--user $(id -u):$(id -g)` substitution, so the whole command line can be
+        // asserted as literal words
+        $imageConfiguration['features'] = ['container-root-user'];
+
+        return $this->getContainer(
+            $imageConfiguration,
+            new RunCommandOptions([], $environmentVariables),
+            [],
+            false,
+        );
+    }
+
+    /**
+     * Lets `/bin/sh` split the `docker run` arguments the same way it does in production and returns the
+     * resulting argument list.
+     *
+     * @return string[]
+     */
+    private function parseCommandArguments(string $runCommand): array
+    {
+        $dockerRunPosition = strpos($runCommand, ' docker run');
+        self::assertNotFalse($dockerRunPosition);
+        $arguments = substr($runCommand, $dockerRunPosition + strlen(' docker run'));
+
+        $process = Process::fromShellCommandline('printf \'%s\0\'' . $arguments);
+        $process->mustRun();
+
+        return explode("\0", rtrim($process->getOutput(), "\0"));
     }
 
     public function testRunCommandWithKeepaliveOverrideUserFeature()

--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -275,9 +275,7 @@ class Container
         setlocale(LC_CTYPE, 'en_US.UTF-8');
         $envs = '';
         foreach ($this->runCommandOptions->getEnvironmentVariables() as $key => $value) {
-            $envs .= ' --env "' .
-                str_replace('"', '\"', (string) $key) . '=' .
-                str_replace('"', '\"', (string) $value). '"';
+            $envs .= ' --env ' . escapeshellarg((string) $key . '=' . (string) $value);
         }
         // phpcs:ignore Generic.Files.LineLength.MaxExceeded
         $command = "sudo timeout --signal=SIGKILL {$this->image->getProcessTimeout()} docker run";


### PR DESCRIPTION
Linear: https://linear.app/keboola/issue/PAT-2005

Before asking for review, check the following:

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. Not applicable — this only concerns the `docker run` shell command line built by the DinD path. The K8s executor passes env vars as structured pod-manifest fields, with no shell involved.

---

In this PR I have...

`Container::getRunCommand()` builds the `docker run` command as a string that is executed through `Process::fromShellCommandline()`, i.e. `/bin/sh -c`. Every argument of that command uses `escapeshellarg()` — except the environment variables, which were hand-escaped with `str_replace('"', '\"', …)` and interpolated into a double-quoted shell string. Double-quote-only escaping does not make a value shell-safe: `$(…)`, backticks and `$VAR` still expand inside double quotes, and a value ending in `\` turns the escaped quote into a literal backslash so that the string terminates early.

```diff
 $envs = '';
 foreach ($this->runCommandOptions->getEnvironmentVariables() as $key => $value) {
-    $envs .= ' --env "' .
-        str_replace('"', '\"', (string) $key) . '=' .
-        str_replace('"', '\"', (string) $value). '"';
+    $envs .= ' --env ' . escapeshellarg((string) $key . '=' . (string) $value);
 }
```

### Behaviour

Unchanged for ordinary values — only the quoting style in the generated command line differs (`--env "KEY=value"` → `--env 'KEY=value'`). `setlocale(LC_CTYPE, 'en_US.UTF-8')` is already called at the top of the method, so multibyte values survive `escapeshellarg()`; `KBC_PROJECTNAME`-style values with diacritics are covered by the existing assertion in `testRunCommandWithContainerRootUserFeature`. The surrounding command structure (`sudo timeout … docker run`) and the intentional `--user $(id -u):$(id -g)` substitution are untouched.

### Tests

`Tests/Docker/Container/ContainerTest.php`:

* `testRunCommandEscapesEnvironmentVariables` — asserts the literal `--env '…'` fragment for command substitution, backticks, `a\";id;#`, a trailing backslash, an embedded single quote, a newline and `$VAR`.
* `testEnvironmentVariablesReachTheShellVerbatim` — hands the generated argument list to `/bin/sh` (the same parse `Process::fromShellCommandline()` performs) and asserts the resulting argv, so the env var must come out as exactly one argument holding the original value, with nothing substituted and no extra words appended.

Both were confirmed to fail against the previous implementation and pass with this change. `composer phpcs` is clean and `composer phpstan` reports no new errors (18 before, 18 after — all pre-existing, in `src/Docker/Runner.php` and the stale baseline). The `container-tests` suite beyond `ContainerTest` needs live Storage API / ECR credentials and was not run locally.

## Release Notes
**Justification, description**

`Container::getRunCommand()` now escapes container environment variables with `escapeshellarg()` instead of hand-escaping double quotes, matching every other argument of the generated `docker run` command. This closes a shell-quoting defect in the DinD job execution path.

**Plans for Customer Communication**

None. No user-visible behaviour change.

**Impact Analysis**

Affects every component job executed through the DinD executor (`docker-bundle` → `sudo docker run`). Environment variables arrive at the container byte-identical to before for all legitimate values, including multibyte ones; only the quoting of the intermediate command line changes. No configuration, API or contract change. The K8s (no-DIND) executor is not affected — it does not build a shell command line.

**Deployment Plan**

Standard: tag `docker-bundle`, bump the dependency in `job-runner`, roll out through the usual job-runner release. No ordering constraints against other services, no migration.

**Rollback Plan**

Revert the commit and release the previous `docker-bundle` tag / previous `job-runner` image. The change is self-contained in one method and carries no state, so rollback is immediate and safe.

**Post-Release Support Plan**

Watch job-queue error rates and `job-runner` logs after rollout for component jobs failing to start, which would be the signal that an environment variable is no longer reaching a container as expected. No dashboards or alerts need changing.
