### PR TITLE
chore: AJDA-3095 update to storage-api-php-client-branch-wrapper v7

### DIFF
--- a/Tests/BaseRunnerTest.php
+++ b/Tests/BaseRunnerTest.php
@@ -21,6 +21,7 @@ use Keboola\StorageApi\Client;
 use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApiBranch\Branch;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\StorageApiToken;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -180,6 +181,7 @@ abstract class BaseRunnerTest extends TestCase
             fn() => new StorageApiToken(
                 $basicClient->verifyToken(),
                 $basicClient->getTokenString(),
+                AuthType::STORAGE_TOKEN,
             ),
         );
 

--- a/Tests/Runner/ArtifactsTest.php
+++ b/Tests/Runner/ArtifactsTest.php
@@ -15,6 +15,7 @@ use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\ListFilesOptions;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Process\Process;
@@ -156,6 +157,7 @@ class ArtifactsTest extends BaseRunnerTest
         $clientWrapper = new ClientWrapper(new ClientOptions(
             url: (string) getenv('STORAGE_API_URL'),
             token: (string) getenv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
         $branchId = $clientWrapper->getDefaultBranch()->id;
 
@@ -222,6 +224,7 @@ class ArtifactsTest extends BaseRunnerTest
         $clientWrapper = new ClientWrapper(new ClientOptions(
             url: (string) getenv('STORAGE_API_URL'),
             token: (string) getenv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
         $branchId = $clientWrapper->getDefaultBranch()->id;
 
@@ -292,6 +295,7 @@ class ArtifactsTest extends BaseRunnerTest
         $clientWrapper = new ClientWrapper(new ClientOptions(
             url: (string) getenv('STORAGE_API_URL'),
             token: (string) getenv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
         $branchId = $clientWrapper->getDefaultBranch()->id;
 
@@ -359,6 +363,7 @@ class ArtifactsTest extends BaseRunnerTest
         $clientWrapper = new ClientWrapper(new ClientOptions(
             url: (string) getenv('STORAGE_API_URL'),
             token: (string) getenv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
         $branchId = $clientWrapper->getDefaultBranch()->id;
 
@@ -499,6 +504,7 @@ class ArtifactsTest extends BaseRunnerTest
         $clientWrapper = new ClientWrapper(new ClientOptions(
             url: (string) getenv('STORAGE_API_URL'),
             token: (string) getenv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
         $branchId = $clientWrapper->getDefaultBranch()->id;
         $uploadedFileIds = [];

--- a/Tests/Runner/StateFileTest.php
+++ b/Tests/Runner/StateFileTest.php
@@ -18,6 +18,7 @@ use Keboola\StorageApi\BranchAwareClient;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 use Monolog\Handler\TestHandler;
@@ -52,6 +53,7 @@ class StateFileTest extends TestCase
         $this->clientWrapper = new ClientWrapper(new ClientOptions(
             self::getRequiredEnv('STORAGE_API_URL'),
             self::getRequiredEnv('STORAGE_API_TOKEN'),
+            authType: AuthType::STORAGE_TOKEN,
         ));
     }
 

--- a/Tests/RunnerPart2/BranchedWorkspaceTest.php
+++ b/Tests/RunnerPart2/BranchedWorkspaceTest.php
@@ -20,6 +20,7 @@ use Keboola\StorageApi\Components;
 use Keboola\StorageApi\DevBranches;
 use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApiBranch\ClientWrapper;
+use Keboola\StorageApiBranch\Factory\AuthType;
 use Keboola\StorageApiBranch\Factory\ClientOptions;
 use Keboola\Temp\Temp;
 
@@ -63,6 +64,7 @@ class BranchedWorkspaceTest extends BaseRunnerTest
             $storageApi->getApiUrl(),
             $storageApi->getTokenString(),
             $branchId,
+            authType: AuthType::STORAGE_TOKEN,
         ));
 
         // run testing job
@@ -94,6 +96,7 @@ class BranchedWorkspaceTest extends BaseRunnerTest
             $storageApi->getApiUrl(),
             $storageApi->getTokenString(),
             $branchId,
+            authType: AuthType::STORAGE_TOKEN,
         ));
 
         // setup configuration inside branch

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "keboola/php-utils": "^5.0",
         "keboola/staging-provider": "^12.2.1",
         "keboola/storage-api-client": "^18.2.3",
-        "keboola/storage-api-php-client-branch-wrapper": "^6.0",
+        "keboola/storage-api-php-client-branch-wrapper": "^7.0",
         "monolog/monolog": "^2.5",
         "mustache/mustache": "^2.13",
         "symfony/http-foundation": "^6.4|^7.0",


### PR DESCRIPTION
Linear: [AJDA-3095](https://linear.app/keboola/issue/AJDA-3095/update-runner-to-v7-storage-api-client-branch-wrapper)

Before asking for review, check the following:

- [x] For any functionality change or the addition of a new feature, I verified if it should also be implemented in the no-DIND version. If so, I created a corresponding task [PST-XXX] under the [no-DIND epic](https://keboola.atlassian.net/browse/PST-918) — dependency bump only, no functionality change, nothing to port.

---

In this PR I have...

## Description

Bumped `keboola/storage-api-php-client-branch-wrapper` to `^7.0`.

`input-mapping`, `output-mapping`, `staging-provider` and `job-queue-artifacts` already require the wrapper at `^7.0`, so with the runner pinned at `^6.0` Composer could not resolve their current releases — the runner was the last consumer holding the upgrade back.

Two v7 BC breaks needed adapting to, both in test setup only (production code never builds the wrapper itself — it receives a `ClientWrapper` via DI):

- `StorageApiToken::__construct()` now takes a non-nullable `AuthType` as its third argument; the implicit `STORAGE_TOKEN` fallback is gone.
- `ClientOptions::getClientConstructOptions()` now throws when a token is set without an `authType` (was a deprecation in 6.8).

The removed `StorageClientRequestFactory` and `ClientOptions::$runIdGenerator` are not used anywhere in this repo, so no changes were needed there.

## Justification

Unblocks releasing the pending IM/OM changes — see the linked issue.

## Plans for Customer Communication

None.

## Impact Analysis

Low. No behavior change in the runner itself; all edits are in tests. The consumer (job-runner) constructs the `ClientWrapper` and must already be on wrapper v7 with an explicit `authType`, which `StorageClientPlainFactory` sets.

One thing to be aware of: wrapper 7.1.0 narrowed its own `symfony/validator` requirement to `^7.1|^8.0`. This repo still declares `^6.4|^7.0`, so the effective resolution is now Symfony 7.1+ — projects that pin `symfony/validator` to 6.x will no longer be able to install this library. Left the declared constraint as-is to keep the diff to the intended change; worth narrowing separately if we want the composer.json to state the real range.

Not behind a feature flag.

## Deployment Plan

Release a tagged version.

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.

## Testing

`composer check` (validate + phpcs + phpstan max) passes in the dev container against wrapper 7.1.0 under PHP 8.2. `Tests/Runner/StateFileTest.php` — which builds a real `ClientWrapper` — passes locally except for 4 cases that fail on missing local AWS KMS credentials (`Failed to obtain encryption key`), unrelated to this change. Full suite runs in CI.
